### PR TITLE
Bump webpack-related gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'clockwork', '~> 2.0', '>= 2.0.2'
 gem 'daemons'
 gem 'delayed_job_active_record'
-gem 'webpacker', '~> 3.0'
+gem 'webpacker', '~> 3.2'
 
 # Improving models
 gem 'audited', '~> 4.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,7 +273,7 @@ GEM
     public_suffix (3.0.0)
     puma (3.10.0)
     rack (2.0.4)
-    rack-proxy (0.6.2)
+    rack-proxy (0.6.4)
       rack
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
@@ -416,7 +416,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    webpacker (3.0.2)
+    webpacker (3.4.3)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
@@ -478,7 +478,7 @@ DEPENDENCIES
   wannabe_bool
   web-console (>= 3.3.0)
   webmock
-  webpacker (~> 3.0)
+  webpacker (~> 3.2)
 
 RUBY VERSION
    ruby 2.4.4p296

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "vue": "^2.4.4",
     "vue-loader": "^13.0.5",
     "vue-template-compiler": "^2.4.4",
-    "vue-turbolinks": "^2.0.0",
+    "vue-turbolinks": "^2.0.3",
     "vuex": "^2.4.1",
     "webpack": "^3.6.0",
     "webpack-manifest-plugin": "^1.3.2",


### PR DESCRIPTION
Shouldn’t change much; there are webpack-dev-server troubles that _should_ be fixed, according to the changelog, but 🤷‍♂️ .