### PR TITLE
Auto-approve users from know safe domains

### DIFF
--- a/app/views/mailers/admin_mailer/new_user_created_notification.html.haml
+++ b/app/views/mailers/admin_mailer/new_user_created_notification.html.haml
@@ -1,6 +1,10 @@
 %p= t('.hello')
 %p= t('.user_has_signed_up', full_name: @user.full_name, email: @user.email)
-- link_to_activate_account = link_to t('.click_here'), edit_admin_user_url(@user)
-%p= t('.activate_its_account_html', click_here_link: link_to_activate_account)
+- if @user.is_approved?
+ - link_to_account = link_to t('.click_here'), admin_user_url(@user)
+ %p= t('.view_their_account_html', click_here_link: link_to_account)
+- else
+ - link_to_activate_account = link_to t('.click_here'), edit_admin_user_url(@user)
+ %p= t('.activate_their_account_html', click_here_link: link_to_activate_account)
 - link_to_root = link_to t('app_name'), root_url
 %p= t('.reso_app_html', link_to_root: link_to_root)

--- a/config/locales/views/mailers/admin_mailer.fr.yml
+++ b/config/locales/views/mailers/admin_mailer.fr.yml
@@ -2,11 +2,12 @@ fr:
   mailers:
     admin_mailer:
       new_user_created_notification:
-        subject: "[Réso] %{full_name} vient de s’inscrire !"
+        subject: "[Réso] %{full_name} vient de s’inscrire"
         hello: Bonjour,
-        user_has_signed_up: L’utilisateur %{full_name} <%{email}> vient de s’inscrire.
-        activate_its_account_html: Pour valider son compte, veuillez %{click_here_link}.
-        click_here: cliquer ici
+        user_has_signed_up: "%{full_name} <%{email}> vient de s’inscrire."
+        view_their_account_html: "%{click_here_link} pour consulter son compte."
+        activate_their_account_html: "%{click_here_link} pour valider son compte."
+        click_here: Cliquez ici
         reso_app_html: L’application %{link_to_root}.
       new_user_approved_notification:
         subject: "Re: [Réso] %{full_name} vient de s’inscrire !"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,5 +14,9 @@ FactoryBot.define do
     password_confirmation 'password'
     confirmed_at { Time.zone.now }
     is_approved true
+
+    trait :just_registered do
+      is_approved false
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -86,4 +86,22 @@ RSpec.describe User, type: :model do
 
     it { expect(user.full_name_with_role).to eq 'Ivan Collombet, Business Developer, DINSIC' }
   end
+
+  describe '#auto_approve_if_whitelisted_domain callback' do
+    subject { user.is_approved? }
+
+    let(:user) { create(:user, :just_registered, email: email) }
+
+    context 'with an unkown email domain' do
+      let(:email) { 'user@example.com' }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'with a kown email domain' do
+      let(:email) { 'user@beta.gouv.fr' }
+
+      it { is_expected.to be_truthy }
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe User, type: :model do
 
     describe 'administrator_of_territory' do
       it do
-        user1 = create :user, first_name:'bb', last_name:'bb'
+        user1 = create :user, first_name: 'bb', last_name: 'bb'
         create :territory_user, user: user1
-        user2 = create :user, first_name:'aa', last_name:'aa'
+        user2 = create :user, first_name: 'aa', last_name: 'aa'
         create :territory_user, user: user2
         user3 = create :user, contact_page_order: 2
         create :territory_user, user: user3


### PR DESCRIPTION
Bypass the manual admin validation for users from known domains. Users still have to confirm their email address, it’s just the additional approval.

The list of domain is currently hardcoded; we’ll see later if we need something more flexible.