### PR TITLE
Show Active users on the Dashboard

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -26,7 +26,44 @@ ActiveAdmin.register_page 'Dashboard' do
           end
         end
       end
-      column do
+      column class: 'attributes_table' do
+        panel I18n.t('active_admin.dashboard_welcome.user_stats') do
+          table do
+            tr class: 'row' do
+              th I18n.t('active_admin.dashboard_welcome.registered_users')
+              td User.not_admin.count
+            end
+            range = (Time.now - 30.days)..Time.now
+            tr class: 'row' do
+              th I18n.t('active_admin.dashboard_welcome.searchers')
+              td User.not_admin.active_searchers(range).count
+            end
+            tr class: 'row' do
+              th I18n.t('active_admin.dashboard_welcome.diagnosers_2')
+              td User.not_admin.active_diagnosers(range, 2).count
+            end
+            tr class: 'row' do
+              th I18n.t('active_admin.dashboard_welcome.diagnosers_3')
+              td User.not_admin.active_diagnosers(range, 3).count
+            end
+            tr class: 'row' do
+              th I18n.t('active_admin.dashboard_welcome.diagnosers_4')
+              td User.not_admin.active_diagnosers(range, 4).count
+            end
+            tr class: 'row' do
+              th I18n.t('active_admin.dashboard_welcome.diagnosers_5')
+              td User.not_admin.active_diagnosers(range, 5).count
+            end
+            tr class: 'row' do
+              th I18n.t('active_admin.dashboard_welcome.answered_taken_care_of')
+              td User.not_admin.active_answered(range, [1, 2]).count
+            end
+            tr class: 'row' do
+              th I18n.t('active_admin.dashboard_welcome.answered_solved')
+              td User.not_admin.active_answered(range, [2]).count
+            end
+          end
+        end
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ApplicationRecord
 
   has_many :territory_users
   has_many :territories, through: :territory_users
+  has_many :visits, foreign_key: 'advisor_id'
+  has_many :searches
 
   validates :first_name, :email, :phone_number, presence: true
 

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -4,6 +4,15 @@ fr:
     dashboard_welcome:
       useful_links: Liens utiles
       invite_users: Inviter des utilisateurs
+      user_stats: Utilisateurs (30 derniers jours)
+      registered_users: Inscrits
+      searchers: …ont fait au moins une recherche
+      diagnosers_2: …ont créé au moins un diagnostic
+      diagnosers_3: …ont saisi les besoins (step 2)
+      diagnosers_4: …ont saisi le contact (step 3)
+      diagnosers_5: …ont lancé la mise en relation (step 4)
+      answered_taken_care_of: …qui a été pris en charge
+      answered_solved: …qui a résolu un besoin
     user:
       user_info: Informations utilisateur
       user_activation: Validation du compte

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -67,6 +67,45 @@ RSpec.describe User, type: :model do
         expect(User.not_admin).to eq [regular_user]
       end
     end
+
+    describe 'active_searchers' do
+      it do
+        searcher = create :user, searches: [(create :search, created_at: 1.day.ago)]
+        create :user, searches: [(create :search, created_at: 2.months.ago)]
+
+        last_30_days = (30.days.ago)..Time.now
+        expect(User.active_searchers(last_30_days)).to eq [searcher]
+      end
+    end
+
+    describe 'active_diagnosers' do
+      it do
+        diagnosis = create :diagnosis, step: 3
+        visit = create :visit, created_at: 1.day.ago, diagnosis: diagnosis
+        diagnoser = create :user, visits: [visit]
+
+        last_30_days = (30.days.ago)..Time.now
+
+        expect(User.active_diagnosers(last_30_days, 3)).to eq [diagnoser]
+        expect(User.active_diagnosers(last_30_days, 4)).to eq []
+      end
+    end
+
+    describe 'active_answered' do
+      it do
+        expert = create :selected_assistance_expert, status: 2
+        need = create :diagnosed_need, selected_assistance_experts: [expert]
+        diagnosis = create :diagnosis, diagnosed_needs: [need]
+        visit = create :visit, created_at: 1.day.ago, diagnosis: diagnosis
+        active_user = create :user, visits: [visit]
+
+        last_30_days = (30.days.ago)..Time.now
+
+        expect(User.active_answered(last_30_days, [1,2])).to eq [active_user]
+        expect(User.active_answered(last_30_days, [3])).to eq []
+      end
+    end
+
   end
 
   describe 'full_name' do


### PR DESCRIPTION
A quick hack to display the number of “active” users on the admin dashboard.
(Active users here are users who made a visit that was actually taken into account in the last 30 days.)

* [x] also filter visits that were taken into account
* [x] add quick tests
* [x] slightly better UI, maybe.