### PR TITLE
Allow mass-import territory cities from admin panel

### DIFF
--- a/app/admin/territory.rb
+++ b/app/admin/territory.rb
@@ -2,7 +2,10 @@
 
 ActiveAdmin.register Territory do
   menu priority: 8
-  permit_params :name
+  permit_params :name,
+                :city_codes,
+                territory_cities: %i[id city_code _create _update _destroy]
+
 
   show do
     attributes_table do
@@ -23,6 +26,18 @@ ActiveAdmin.register Territory do
         column :institution
       end
     end
+  end
+
+  form do |f|
+    f.inputs I18n.t('activerecord.attributes.territory.name') do
+      f.input :name
+    end
+
+    f.inputs I18n.t('activerecord.attributes.territory_city.city_code') do
+      f.input :city_codes
+    end
+
+    f.actions
   end
 
   filter :experts, collection: -> { Expert.ordered_by_names }

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class Territory < ApplicationRecord
-  has_many :territory_cities
+  has_many :territory_cities, dependent: :destroy
   has_many :expert_territories
   has_many :experts, through: :expert_territories
+
+  accepts_nested_attributes_for :territory_cities
 
   scope :ordered_by_name, (-> { order(:name) })
 
@@ -13,5 +15,23 @@ class Territory < ApplicationRecord
 
   def city_codes
     territory_cities.pluck(:city_code)
+  end
+
+  def city_codes=(codes_raw)
+    wanted_codes = codes_raw.split(/[,\s]/).delete_if(&:empty?)
+    if wanted_codes.any? { |code| code !~ /[0-9AB]{5}/ }
+      raise 'Invalid city codes'
+    end
+
+    existing_codes = city_codes
+
+    codes_to_remove = existing_codes - wanted_codes
+    territory_cities.where(city_code: codes_to_remove)
+                    .destroy_all
+
+    codes_to_add = wanted_codes - existing_codes
+    codes_to_add.each{ |c|
+      TerritoryCity.create(territory: self, city_code: c)
+    }
   end
 end

--- a/spec/models/territory_spec.rb
+++ b/spec/models/territory_spec.rb
@@ -32,4 +32,45 @@ RSpec.describe Territory, type: :model do
       it { is_expected.to eq [] }
     end
   end
+
+  describe 'city_codes=' do
+    subject { territory.city_codes }
+
+    let(:territory) { create :territory }
+
+    context 'with invalid data' do
+      subject(:set_city_codes) { territory.city_codes = raw_codes }
+
+      let(:raw_codes) { 'baddata morebaddata' }
+
+      it { expect { set_city_codes }.to raise_error 'Invalid city codes'}
+    end
+
+    context 'with empty data' do
+      let(:raw_codes) { '' }
+      before { territory.city_codes = raw_codes }
+
+      it { is_expected.to eq [] }
+    end
+
+    context 'with proper values' do
+      let(:raw_codes) { '12345, 12346' }
+      before { territory.city_codes = raw_codes }
+
+      it { is_expected.to eq %w[12345 12346] }
+    end
+
+    context 'with previous values' do
+      before {
+        create :territory_city, territory: territory, city_code: 10_001
+        create :territory_city, territory: territory, city_code: 10_002
+        territory.city_codes = raw_codes
+      }
+
+      let(:raw_codes) { '10002, 10003' }
+
+      it { is_expected.to eq %w[10002 10003] }
+    end
+
+  end
 end


### PR DESCRIPTION
Allow admins to copy-paste the city codes in the admin panel directly in the admin panel.
