### PR TITLE
Allow filtering selected experts by territory

### DIFF
--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -86,6 +86,7 @@ ActiveAdmin.register Expert do
     f.actions
   end
 
+  filter :territories, collection: -> { Territory.order(:name) }
   filter :institution, collection: -> { Institution.ordered_by_name }
   filter :assistances, collection: -> { Assistance.order(:title).map { |a| ["#{a.title} (#{a.id})", a.id] } }
   filter :first_name
@@ -95,5 +96,4 @@ ActiveAdmin.register Expert do
   filter :role
   filter :created_at
   filter :updated_at
-  filter :territories, collection: -> { Territory.order(:name) }
 end

--- a/app/admin/selected_assistance_expert.rb
+++ b/app/admin/selected_assistance_expert.rb
@@ -47,6 +47,7 @@ ActiveAdmin.register SelectedAssistanceExpert do
     f.actions
   end
 
+  filter :territories, collection: -> { Territory.order(:name) }
   filter :diagnosed_need, collection: -> { DiagnosedNeed.order(created_at: :desc).pluck(:id) }
   filter :expert_full_name
   filter :expert_institution_name
@@ -54,7 +55,7 @@ ActiveAdmin.register SelectedAssistanceExpert do
   filter :status
   filter :created_at
   filter :updated_at
-
+  
   controller do
     def update
       super

--- a/app/admin/territory.rb
+++ b/app/admin/territory.rb
@@ -34,6 +34,32 @@ ActiveAdmin.register Territory do
         column :institution
       end
     end
+
+    panel I18n.t('active_admin.territories.contacted_experts') do
+      table_for territory.selected_assistance_experts
+                    .includes(diagnosed_need: [diagnosis: [visit: [facility: :company]]])
+                    .includes(:expert)
+                    .order(created_at: :desc) do
+        column(:id) do |selected_expert|
+          link_to(selected_expert.id, admin_selected_assistance_expert_path(selected_expert))
+        end
+        column :created_at
+        column(I18n.t('activerecord.attributes.visit.facility')) do |selected_expert|
+          selected_expert.diagnosed_need&.diagnosis&.visit&.facility
+        end
+        column(:diagnosed_need) do |selected_expert|
+          need = selected_expert.diagnosed_need
+          link_to(need.question_label, admin_diagnosed_need_path(need))
+        end
+        column :expert_full_name do |selected_expert|
+          link_to("#{selected_expert.expert_full_name} (#{selected_expert.expert_institution_name})", admin_expert_path(selected_expert.expert))
+        end
+        column :status do |selected_expert|
+          I18n.t("activerecord.attributes.selected_assistance_expert.statuses.#{selected_expert.status}")
+        end
+      end
+    end
+
   end
 
   form do |f|

--- a/app/admin/territory.rb
+++ b/app/admin/territory.rb
@@ -19,6 +19,14 @@ ActiveAdmin.register Territory do
       end
     end
 
+    panel I18n.t('active_admin.territories.relais') do
+      table_for territory.users do
+        column :full_name, (proc { |user| link_to(user.full_name, admin_user_path(user)) })
+        column :role
+        column :institution
+      end
+    end
+
     panel I18n.t('active_admin.territories.experts') do
       table_for territory.experts.includes(:institution) do
         column :full_name, (proc { |expert| link_to(expert.full_name, admin_expert_path(expert)) })

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -24,6 +24,11 @@ ActiveAdmin.register User do
     column :sign_in_count
     column :created_at
     column :is_approved
+    column(:territories) do |user|
+      safe_join(user.territories.map do |territory|
+        link_to territory.name, admin_territory_path(territory)
+      end, ', '.html_safe)
+    end
     column('Impersonate') { |user| link_to('Impersonate', impersonate_engine.impersonate_user_path(user.id)) }
     actions
   end
@@ -53,6 +58,7 @@ ActiveAdmin.register User do
     f.actions
   end
 
+  filter :territories, collection: -> { Territory.order(:name) }
   filter :first_name
   filter :last_name
   filter :email

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -7,6 +7,7 @@ class Expert < ApplicationRecord
 
   has_many :assistances_experts, dependent: :destroy
   has_many :assistances, through: :assistances_experts
+  has_many :selected_assistance_experts, through: :assistances_experts
   has_many :expert_territories, dependent: :destroy
   has_many :territories, through: :expert_territories
   has_many :territory_cities, through: :territories

--- a/app/models/selected_assistance_expert.rb
+++ b/app/models/selected_assistance_expert.rb
@@ -9,6 +9,8 @@ class SelectedAssistanceExpert < ApplicationRecord
   belongs_to :diagnosed_need
   belongs_to :assistance_expert, foreign_key: :assistances_experts_id
   belongs_to :territory_user
+  has_one :expert, through: :assistance_expert
+  has_many :territories, through: :expert
 
   validates :diagnosed_need, presence: true
   validates_with SelectedAssistanceExpertValidator

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -4,6 +4,7 @@ class Territory < ApplicationRecord
   has_many :territory_cities, dependent: :destroy
   has_many :expert_territories
   has_many :experts, through: :expert_territories
+  has_many :selected_assistance_experts, through: :experts
   has_many :territory_users
   has_many :users, through: :territory_users
 

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -4,6 +4,8 @@ class Territory < ApplicationRecord
   has_many :territory_cities, dependent: :destroy
   has_many :expert_territories
   has_many :experts, through: :expert_territories
+  has_many :territory_users
+  has_many :users, through: :territory_users
 
   accepts_nested_attributes_for :territory_cities
 

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -20,6 +20,7 @@ fr:
     territories:
       experts: Référents
       relais: Relais locaux
+      contacted_experts: Mises en relation
     assistances:
       expert: Référent
       experts: Les référents pour cette aide

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -18,7 +18,8 @@ fr:
       user_activation: Validation du compte
       user_admin: A les privilèges administrateur
     territories:
-      experts: Les référents pour ce territoire
+      experts: Référents
+      relais: Relais locaux
     assistances:
       expert: Référent
       experts: Les référents pour cette aide


### PR DESCRIPTION
Added selected_assistance_expert -> territories associations and allow filtering by territories in the admin.

https://trello.com/c/9RRj0rs1/193-dans-ladmin-permettre-de-filtrer-les-référents-contactés-par-territoire