### PR TITLE
Remove the additional “next month” line in the stats page

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -58,8 +58,9 @@ class StatsController < ApplicationController
   end
 
   def history_date_ranges
+    # Make sure min and max are in the same timezone (The one defined for Rails / ActiveSupport in application.rb)
     min_date = User.not_admin.first.created_at.beginning_of_month
-    max_date = Time.now.advance(months: 1).beginning_of_month
+    max_date = Time.zone.now.advance(months: 1).beginning_of_month
     ranges = []
     start_date, end_date = min_date, min_date.advance(months: 1)
     while start_date < max_date
@@ -69,5 +70,4 @@ class StatsController < ApplicationController
     end
     ranges
   end
-
 end

--- a/spec/controllers/stats_controller_spec.rb
+++ b/spec/controllers/stats_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe StatsController, type: :controller do
+
+  describe 'history_date_ranges' do
+    subject { controller.instance_eval{ history_date_ranges } }
+
+    before { create :user, created_at: date_1}
+
+    context 'with a single recent user' do
+      let(:date_1) { Time.zone.now }
+
+      it 'returns a single one-month range' do
+        is_expected.to eq [date_1.beginning_of_month..(date_1 + 1.month).beginning_of_month]
+      end
+    end
+
+    context 'with a 15-month old user' do
+      let(:date_1) { Time.zone.now - 15.months }
+
+      it 'returns a 15 ranges array' do
+        subject.count eq 15
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix StatsController::history_date_ranges to respect the Rails timezone

Also add tests for history_date_ranges, although they don’t really allow to exhibit the buggy behaviour.