### PR TITLE
Improve Admin view for companies / facilities

### DIFF
--- a/app/admin/company.rb
+++ b/app/admin/company.rb
@@ -9,4 +9,18 @@ ActiveAdmin.register Company do
   filter :legal_form_code
   filter :created_at
   filter :updated_at
+
+  show do
+    default_main_content
+
+    panel I18n.t('activerecord.attributes.company.facilities') do
+      table_for company.facilities do
+        column :siret
+        column :city_code
+        column :naf_code
+        column :readable_locality
+      end
+    end
+  end
+
 end

--- a/app/admin/facility.rb
+++ b/app/admin/facility.rb
@@ -3,4 +3,8 @@
 ActiveAdmin.register Facility do
   menu parent: :companies, priority: 1
   includes :company
+
+  preserve_default_filters!
+  remove_filter :company
+  filter :company_name, as: :string, label: I18n.t('activerecord.attributes.facility.company')
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -2,6 +2,7 @@
 
 class Company < ApplicationRecord
   has_many :contacts
+  has_many :facilities
 
   validates :name, presence: true
 

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -10,6 +10,6 @@ class Facility < ApplicationRecord
   scope :in_territory, (->(territory) { where(city_code: territory.city_codes) })
 
   def to_s
-    "#{company.name_short} (#{city_code})"
+    "#{company.name_short} (#{readable_locality})"
   end
 end

--- a/config/locales/active_record.fr.yml
+++ b/config/locales/active_record.fr.yml
@@ -119,6 +119,7 @@ fr:
         company: Entreprise
         siret: SIRET
         city_code: Code commune
+        readable_locality: Commune
       contact:
         first_name: Prénom
         last_name: Nom

--- a/config/locales/active_record.fr.yml
+++ b/config/locales/active_record.fr.yml
@@ -109,6 +109,7 @@ fr:
       company:
         name: Raison sociale
         siren: SIREN
+        facilities: Établissements
       institution:
         name: Raison sociale
         email: Adresse e-mail

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe Facility, type: :model do
   describe 'to_s' do
     subject { facility.to_s }
 
-    let(:facility) { create :facility, city_code: 59_001, company: company }
+    let(:facility) { create :facility, readable_locality: '59600 Maubeuge', company: company }
     let(:company) { create :company, name: 'Mc Donalds' }
 
-    it { is_expected.to eq 'Mc Donalds (59001)' }
+    it { is_expected.to eq 'Mc Donalds (59600 Maubeuge)' }
   end
 end


### PR DESCRIPTION
* Display the list of (known) facilities in the company page
* Filter facilities by company name

That second change is important. In most ActiveAdmin pages, the default filter for a `has_many` association is a `:select` drop down menu, which doesn’t make sense when there’s a lot of items. Using `filter :<association>_<attribute>, as: :string` displays a text field instead, and we should use it everywhere in our AA pages.