### PR TITLE
Display matches for territory

### DIFF
--- a/app/admin/company.rb
+++ b/app/admin/company.rb
@@ -21,6 +21,36 @@ ActiveAdmin.register Company do
         column :readable_locality
       end
     end
-  end
 
+    panel I18n.t('active_admin.territories.contacted_experts') do
+      table_for SelectedAssistanceExpert.of_facilities(company.facilities)
+                    .includes(diagnosed_need: [diagnosis: [visit: [facility: :company]]])
+                    .includes(:expert)
+                    .order(created_at: :desc) do
+        column(:id) do |selected_expert|
+          link_to(selected_expert.id, admin_selected_assistance_expert_path(selected_expert))
+        end
+        column :created_at
+        column(I18n.t('activerecord.attributes.visit.facility')) do |selected_expert|
+          selected_expert.diagnosed_need&.diagnosis&.visit&.facility
+        end
+        column(:diagnosed_need) do |selected_expert|
+          need = selected_expert.diagnosed_need
+          link_to(need.question_label, admin_diagnosed_need_path(need))
+        end
+        column :expert_full_name do |selected_expert|
+          expert = selected_expert.expert
+          if expert.present?
+            link_to(selected_expert.expert_description, admin_expert_path(expert))
+          else
+            I18n.t('active_admin.selected_assistance_experts.deleted', expert: selected_expert.expert_description)
+          end
+        end
+        column :status do |selected_expert|
+          I18n.t("activerecord.attributes.selected_assistance_expert.statuses.#{selected_expert.status}")
+        end
+      end
+    end
+
+  end
 end

--- a/app/admin/territory.rb
+++ b/app/admin/territory.rb
@@ -52,7 +52,12 @@ ActiveAdmin.register Territory do
           link_to(need.question_label, admin_diagnosed_need_path(need))
         end
         column :expert_full_name do |selected_expert|
-          link_to("#{selected_expert.expert_full_name} (#{selected_expert.expert_institution_name})", admin_expert_path(selected_expert.expert))
+          expert = selected_expert.expert
+          if expert.present?
+            link_to(selected_expert.expert_description, admin_expert_path(expert))
+          else
+            I18n.t('active_admin.selected_assistance_experts.deleted', expert: selected_expert.expert_description)
+          end
         end
         column :status do |selected_expert|
           I18n.t("activerecord.attributes.selected_assistance_expert.statuses.#{selected_expert.status}")

--- a/app/admin/territory.rb
+++ b/app/admin/territory.rb
@@ -36,7 +36,7 @@ ActiveAdmin.register Territory do
     end
 
     panel I18n.t('active_admin.territories.contacted_experts') do
-      table_for territory.selected_assistance_experts
+      table_for SelectedAssistanceExpert.in_territory(territory)
                     .includes(diagnosed_need: [diagnosis: [visit: [facility: :company]]])
                     .includes(:expert)
                     .order(created_at: :desc) do

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -20,7 +20,8 @@ class Diagnosis < ApplicationRecord
   scope :reverse_chronological, (-> { order(created_at: :desc) })
   scope :in_progress, (-> { where(step: [1..LAST_STEP - 1]) })
   scope :completed, (-> { where(step: LAST_STEP) })
-  scope :in_territory, (->(territory) { joins(visit: :facility).merge(Facility.in_territory(territory)) })
+  scope :in_territory, (->(territory) { of_facilities(Facility.in_territory(territory))})
+  scope :of_facilities, (->(facilities) { joins(:visit).merge(Visit.where(facility: facilities))})
   scope :available_for_expert, (lambda do |expert|
     joins(diagnosed_needs: [selected_assistance_experts: [assistance_expert: :expert]])
       .where(diagnosed_needs: { selected_assistance_experts: { assistance_expert: { experts: { id: expert.id } } } })

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -10,6 +10,6 @@ class Facility < ApplicationRecord
   scope :in_territory, (->(territory) { where(city_code: territory.city_codes) })
 
   def to_s
-    "#{company.name_short} (#{readable_locality})"
+    "#{company.name_short} (#{readable_locality || city_code})"
   end
 end

--- a/app/models/selected_assistance_expert.rb
+++ b/app/models/selected_assistance_expert.rb
@@ -33,6 +33,8 @@ class SelectedAssistanceExpert < ApplicationRecord
   end)
 
   scope :in_territory, (->(territory) { of_diagnoses(Diagnosis.in_territory(territory))})
+  scope :of_facilities, (->(facilities) { of_diagnoses(Diagnosis.of_facilities(facilities))})
+
   def status_closed?
     status_done? || status_not_for_me?
   end

--- a/app/models/selected_assistance_expert.rb
+++ b/app/models/selected_assistance_expert.rb
@@ -32,6 +32,7 @@ class SelectedAssistanceExpert < ApplicationRecord
     where(diagnosed_need_id: ids).updated_more_than_five_days_ago
   end)
 
+  scope :in_territory, (->(territory) { of_diagnoses(Diagnosis.in_territory(territory))})
   def status_closed?
     status_done? || status_not_for_me?
   end

--- a/app/models/selected_assistance_expert.rb
+++ b/app/models/selected_assistance_expert.rb
@@ -37,6 +37,10 @@ class SelectedAssistanceExpert < ApplicationRecord
     status_done? || status_not_for_me?
   end
 
+  def expert_description
+    "#{expert_full_name} (#{expert_institution_name})"
+  end
+
   private
 
   def update_taken_care_of_at

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -4,7 +4,6 @@ class Territory < ApplicationRecord
   has_many :territory_cities, dependent: :destroy
   has_many :expert_territories
   has_many :experts, through: :expert_territories
-  has_many :selected_assistance_experts, through: :experts
   has_many :relays
   has_many :users, through: :relays
 

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -25,3 +25,5 @@ fr:
       add_assistance: Ajouter une nouvelle aide
     institutions:
       experts: Réferents
+    selected_assistance_experts:
+      deleted: '%{expert} (supprimé)'


### PR DESCRIPTION
(waiting for #126)

In the ActiveAdmin page, display the Matches (aka SelectedAssistanceExperts) for the visits of the facilities of a company, and for the facilities in the cities of a territory.