### PR TITLE
Fix Webpacker compilation in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-latest": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
     "coffee-loader": "^0.8.0",
     "coffee-script": "^1.12.7",
     "coffeescript": "1.12.7",
@@ -47,7 +48,6 @@
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
     "eslint": "^4.8.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-config-vue": "^2.0.2",


### PR DESCRIPTION
```
       ERROR in ./app/javascript/packs/common/babel-polyfill.js
       Module build failed: Error: Couldn't find preset "stage-0"
```

Not sure why this would start to fail after bumping Rails, but OK.