### PR TITLE
Use the regular user_impersonate gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'webpacker'
 # Improving models
 gem 'audited', '~> 4.5'
 gem 'devise'
-gem 'user_impersonate2', require: 'user_impersonate', github: 'rcook/user_impersonate2'
+gem 'user_impersonate2', require: 'user_impersonate'
 
 # Misc
 gem 'activeadmin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/rcook/user_impersonate2.git
-  revision: 3b33c29c9dc041140d34cf76219da8af607dec8f
-  specs:
-    user_impersonate2 (0.13.0)
-      rails (>= 5.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -412,6 +405,8 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     unicode-display_width (1.4.0)
+    user_impersonate2 (0.12.0)
+      rails (>= 5.1.0)
     wannabe_bool (0.7.1)
     warden (1.2.7)
       rack (>= 1.0)
@@ -482,7 +477,7 @@ DEPENDENCIES
   turbolinks
   tzinfo-data
   uglifier
-  user_impersonate2!
+  user_impersonate2
   wannabe_bool
   web-console
   webmock


### PR DESCRIPTION
Actually, rcook/user_impersonate2 now redirects to https://github.com/userimpersonate/user_impersonate2, and (no longer?) instructs to specify the repository.