### PR TITLE
CircleCI: no parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - *bundle_save_cache
   test:
     <<: *defaults
-    parallelism: 3
+    parallelism: 1
     steps:
       - checkout
       - *bundle_restore_cache


### PR DESCRIPTION
rspec runs in 30 seconds on my machine, there’s no need to spin several containers, and it (hopefully) works around the random failures. However, I have no idea (yet) why there’s a 150-second stall once per rspec run on Circle CI

I suspect some tests load the UI, and thus a full webpacker compilation.