### PR TITLE
Fix a crash when displaying diagnosed_needs of deleted questions

### DIFF
--- a/app/models/use_cases/get_diagnosed_needs_with_filtered_assistance_experts.rb
+++ b/app/models/use_cases/get_diagnosed_needs_with_filtered_assistance_experts.rb
@@ -16,8 +16,11 @@ module UseCases
         all_assistances_experts_in_scope = AssistanceExpert.of_city_code(diagnosis.visit.facility.city_code)
           .of_naf_code(diagnosis.visit.facility.naf_code)
         diagnosed_needs.each do |diagnosed_need|
-          diagnosed_need.question.assistances.each do |assistance|
-            assistance.filtered_assistances_experts = assistance.assistances_experts & all_assistances_experts_in_scope
+          question = diagnosed_need.question # the underlying question might have been deleted by admins
+          if question.present?
+            diagnosed_need.question.assistances.each do |assistance|
+              assistance.filtered_assistances_experts = assistance.assistances_experts & all_assistances_experts_in_scope
+            end
           end
         end
       end

--- a/app/views/diagnoses/step4.html.haml
+++ b/app/views/diagnoses/step4.html.haml
@@ -14,9 +14,9 @@
         %table.ui.compact.small.table.celled
           %thead
             %tr
-              %th{ colspan: 3 }= diagnosed_need.question
+              %th{ colspan: 3 }= diagnosed_need.question || diagnosed_need.question_label
           %tbody
-            - assistances_experts = diagnosed_need.question.assistances.flat_map(&:filtered_assistances_experts)
+            - assistances_experts = diagnosed_need.question&.assistances&.flat_map(&:filtered_assistances_experts)
             - if assistances_experts.present?
               = f.fields_for :assistances_experts do |assistance_expert_form|
                 - assistances_experts.each do |assistance_expert|


### PR DESCRIPTION
Questions may be deleted by admins, which basically makes old diagnoses “bad data”. We still might a avoid a crash :D