### PR TITLE
Start refactoring relay/diagnoses

### DIFF
--- a/app/controllers/relays_controller.rb
+++ b/app/controllers/relays_controller.rb
@@ -1,18 +1,12 @@
 # frozen_string_literal: true
 
 class RelaysController < ApplicationController
-  def diagnoses
+  def index
     @relays = current_user.relays.joins(:territory).order('territories.name')
-    relay_diagnoses = @relays.map do |relay|
-      diagnoses = Diagnosis.only_active
-        .includes(visit: [facility: :company])
-        .joins(:diagnosed_needs)
-        .merge(DiagnosedNeed.of_relay(relay))
-        .order('visits.happened_on desc', 'visits.created_at desc')
-        .distinct
-      [relay, diagnoses]
-    end
-    @relay_diagnoses = relay_diagnoses.to_h
+  end
+
+  def show
+    @relay = Relay.find params[:id]
   end
 
   def diagnosis

--- a/app/models/clockwork.rb
+++ b/app/models/clockwork.rb
@@ -10,7 +10,7 @@ module Clockwork
   end
 
   every(1.week, 'send_local_administrators_statistics_email', at: 'Monday 08:30') do
-    RelaysService::MailerService.delay.send_statistics_email
+    RelaysService::MailerService.delay.send_relay_stats_emails
   end
 
   every(1.week, 'send_experts_reminders', at: 'Monday 09:30') do

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -20,4 +20,13 @@ class Relay < ApplicationRecord
       .in_territory(self.territory)
       .reverse_chronological
   end
+
+  def assigned_diagnoses
+    Diagnosis.only_active
+      .includes(visit: [facility: :company])
+      .joins(:diagnosed_needs)
+      .merge(DiagnosedNeed.of_relay(self))
+      .order('visits.happened_on desc', 'visits.created_at desc')
+      .distinct
+  end
 end

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -12,4 +12,12 @@ class Relay < ApplicationRecord
     joins(territory: :territory_cities)
       .where(territories: { territory_cities: { city_code: diagnosis.visit.facility.city_code } })
   end)
+
+  def territory_diagnoses
+    Diagnosis.only_active
+      .includes(visit: [:advisor, facility: [:company]])
+      .includes(diagnosed_needs: [:question, :matches])
+      .in_territory(self.territory)
+      .reverse_chronological
+  end
 end

--- a/app/services/relay_service/mailer_service.rb
+++ b/app/services/relay_service/mailer_service.rb
@@ -13,17 +13,10 @@ module RelayService
       private
 
       def send_statistics_email_to(relay)
-        associations = [visit: [:advisor, facility: [:company]],
-                        diagnosed_needs: %i[question matches]
-]
-        not_admin_territory_diagnoses = Diagnosis.only_active
-          .includes(associations)
-          .of_user(User.not_admin) # remove this and send territory emails to admins?
-          .in_territory(relay.territory)
-          .reverse_chronological
+        diagnoses = relay.territory_diagnoses
 
-        information_hash = generate_statistics_hash not_admin_territory_diagnoses
-        stats_csv = RelayService::CSVGenerator.generate_statistics_csv(not_admin_territory_diagnoses)
+        information_hash = generate_statistics_hash diagnoses
+        stats_csv = RelayService::CSVGenerator.generate_statistics_csv(diagnoses)
 
         RelayMailer.delay.weekly_statistics(relay, information_hash, stats_csv)
       end

--- a/app/services/relay_service/mailer_service.rb
+++ b/app/services/relay_service/mailer_service.rb
@@ -3,16 +3,16 @@
 module RelayService
   class MailerService
     class << self
-      def send_statistics_email
+      def send_relay_stats_emails
         relays = Relay.all.includes(territory: :territory_cities)
         relays.each do |relay|
-          send_statistics_email_to relay
+          send_relay_stats_email_to(relay)
         end
       end
 
       private
 
-      def send_statistics_email_to(relay)
+      def send_relay_stats_email_to(relay)
         diagnoses = relay.territory_diagnoses
 
         information_hash = generate_statistics_hash diagnoses

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -10,7 +10,7 @@
           = t('.diagnoses')
       - if current_user.relays.present?
         .item
-          = link_to diagnoses_relays_path do
+          = link_to relays_path do
             = semantic_icon('dashboard')
             = t('.relay_dashboard')
     - else

--- a/app/views/relays/diagnoses.html.haml
+++ b/app/views/relays/diagnoses.html.haml
@@ -1,19 +1,29 @@
 - meta title: t('.title')
 
-%h1= t('.title')
+%h2= t('.title')
 
-- if @diagnoses.empty?
-  %p= t('.no_diagnoses')
-- else
+- @relay_diagnoses.each do |relay, diagnoses|
   %table.ui.table
     %thead
       %tr
-        %th= t('activerecord.attributes.company.name')
-        %th= t('activerecord.attributes.visit.happened_on')
         %th
+          = relay.territory.name
     %tbody
-      - @diagnoses.each do |diagnosis|
+      - if diagnoses.empty?
         %tr
-          %td= diagnosis.visit.company_name
-          %td= I18n.l diagnosis.visit.happened_on
-          %td= link_to t('.view'), action: 'diagnosis', diagnosis_id: diagnosis.id
+          %td
+            = t('.no_diagnoses')
+      - else
+        - diagnoses.each do |diagnosis|
+          %tr
+            %td.selectable
+              %a{ href: diagnosis_relays_path(diagnosis.id) }
+                .ui.text.medium
+                  = diagnosis.visit.company_description
+                - date = diagnosis.visit.happened_on || diagnosis.visit.created_at.to_date
+                .ui.text.small
+                  %i.calendar.icon
+                  = I18n.l date
+                .ui.text.small
+                  %i.user.icon
+                  = diagnosis.visit.advisor

--- a/app/views/relays/index.html.haml
+++ b/app/views/relays/index.html.haml
@@ -2,12 +2,15 @@
 
 %h2= t('.title')
 
-- @relay_diagnoses.each do |relay, diagnoses|
+- @relays.each do |relay|
+  - diagnoses = relay.assigned_diagnoses
   %table.ui.table
     %thead
       %tr
         %th
           = relay.territory.name
+          %a.ui.right.floated.circular{ href: relay_path(id: relay, format: 'csv') }
+            %i.download.icon.small
     %tbody
       - if diagnoses.empty?
         %tr

--- a/app/views/relays/show.csv.erb
+++ b/app/views/relays/show.csv.erb
@@ -1,0 +1,1 @@
+<%= RelayService::CSVGenerator.generate_statistics_csv(@relay.assigned_diagnoses) %>

--- a/config/locales/views/layouts.fr.yml
+++ b/config/locales/views/layouts.fr.yml
@@ -2,7 +2,7 @@ fr:
   layouts:
     navbar:
       diagnoses: Analyses
-      relay_dashboard: Mon tableau de bord
+      relay_dashboard: Territoires
       know_more: En savoir plus
       sign_out: Me déconnecter
       dashboard: Admin

--- a/config/locales/views/relays.fr.yml
+++ b/config/locales/views/relays.fr.yml
@@ -1,6 +1,7 @@
 fr:
   relays:
-    diagnoses:
+    index:
       title: Suivi des demandes
       no_diagnoses: Il n’y a aucune analyse sur laquelle vous êtes référent pour le moment.
       view: Afficher
+      summary: Résumé

--- a/config/locales/views/relays.fr.yml
+++ b/config/locales/views/relays.fr.yml
@@ -1,7 +1,5 @@
 fr:
   relays:
     index:
-      title: Suivi des demandes
-      no_diagnoses: Il n’y a aucune analyse sur laquelle vous êtes référent pour le moment.
-      view: Afficher
-      summary: Résumé
+      title: Suivi des territoires
+      no_diagnoses: Aucune analyse dont vous êtes référent.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,9 +53,8 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :relays, only: %i[] do
+  resources :relays, only: %i[index show] do
     collection do
-      get :diagnoses
       get 'diagnoses/:diagnosis_id' => 'relays#diagnosis', as: :diagnosis
       patch :update_status
     end

--- a/spec/controllers/relays_controller_spec.rb
+++ b/spec/controllers/relays_controller_spec.rb
@@ -5,10 +5,10 @@ require 'rails_helper'
 RSpec.describe RelaysController, type: :controller do
   login_user
 
-  describe 'GET #diagnoses' do
+  describe 'GET #index' do
     let(:diagnosis) { create :diagnosis }
 
-    before { get :diagnoses }
+    before { get :index }
 
     context 'current user is not relay' do
       it { expect(response).to be_successful }

--- a/spec/services/relay_service/mailer_service_spec.rb
+++ b/spec/services/relay_service/mailer_service_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 describe RelayService::MailerService do
   before { ENV['APPLICATION_EMAIL'] = 'contact@mailrandom.fr' }
 
-  describe 'send_statistics_email' do
-    subject(:send_statistics_email) { described_class.send_statistics_email }
+  describe 'send_relay_stats_emails' do
+    subject(:send_relay_stats_emails) { described_class.send_relay_stats_emails }
 
     let(:not_admin_user) { create :user, is_admin: false }
 
@@ -33,7 +33,7 @@ describe RelayService::MailerService do
       end
 
       context 'no data' do
-        before { send_statistics_email }
+        before { send_relay_stats_emails }
 
         it 'sends one email' do
           expect(RelayMailer).to have_received(:weekly_statistics).once.with(
@@ -70,7 +70,7 @@ describe RelayService::MailerService do
           create :diagnosis, step: 1, visit: visit1, created_at: 2.weeks.ago, updated_at: 2.weeks.ago
           create_list :match, 3, diagnosed_need: diagnosed_need
 
-          send_statistics_email
+          send_relay_stats_emails
         end
 
         it 'sends one email with data' do


### PR DESCRIPTION
* Style and names
* Change routes of the `relays/` section for more standard `index` and `show` pages.
* Display one section per relay (territory) in the index page (even though most relay (users) only manage one territory)
* Allow downloading a CSV summary for each relay (territory)