### PR TITLE
UI and behavior adjustments in the relay dashboard

### DIFF
--- a/app/controllers/experts_controller.rb
+++ b/app/controllers/experts_controller.rb
@@ -13,7 +13,7 @@ class ExpertsController < ApplicationController
 ]
     @diagnosis = Diagnosis.available_for_expert(@expert).includes(associations).find(params[:diagnosis_id])
     UseCases::UpdateExpertViewedPageAt.perform(diagnosis_id: params[:diagnosis_id].to_i, expert_id: @expert.id)
-    @current_user_diagnosed_needs = @diagnosis.diagnosed_needs.includes(:matches).of_expert(@expert)
+    @current_user_diagnosed_needs = @diagnosis.needs_for(@expert)
   end
 
   def update_status

--- a/app/controllers/relays_controller.rb
+++ b/app/controllers/relays_controller.rb
@@ -3,6 +3,9 @@
 class RelaysController < ApplicationController
   def index
     @relays = current_user.relays.joins(:territory).order('territories.name')
+    if @relays.count == 1
+      redirect_to relay_path(@relays.first)
+    end
   end
 
   def show

--- a/app/controllers/relays_controller.rb
+++ b/app/controllers/relays_controller.rb
@@ -18,8 +18,8 @@ class RelaysController < ApplicationController
 ]
     @diagnosis = Diagnosis.includes(associations).find(params[:diagnosis_id])
     check_relay_access
-    @current_user_diagnosed_needs = @diagnosis.diagnosed_needs.of_relay(@relay)
-      .includes(:matches)
+    @current_user_diagnosed_needs = @diagnosis.needs_for(@relay)
+
     render 'experts/diagnosis'
   end
 

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -47,4 +47,13 @@ class Diagnosis < ApplicationRecord
   def can_be_viewed_by?(user)
     visit.can_be_viewed_by?(user)
   end
+
+  def needs_for(relay_or_expert)
+    needs = diagnosed_needs.includes(:matches)
+    if relay_or_expert.is_a?(Expert)
+      needs.of_expert(relay_or_expert)
+    elsif relay_or_expert.is_a?(Relay)
+      needs.of_relay(relay_or_expert)
+    end
+  end
 end

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -26,6 +26,7 @@ class Relay < ApplicationRecord
       .includes(visit: [facility: :company])
       .joins(:diagnosed_needs)
       .merge(DiagnosedNeed.of_relay(self))
+      .merge(Match.with_status([:quo, :taking_care]))
       .order('visits.happened_on desc', 'visits.created_at desc')
       .distinct
   end

--- a/app/views/relays/_assigned_diagnoses.html.haml
+++ b/app/views/relays/_assigned_diagnoses.html.haml
@@ -1,0 +1,25 @@
+- assigned_diagnoses = relay.assigned_diagnoses
+- if assigned_diagnoses.present?
+  .ui.segments
+    %h3.ui.segment.block.header
+      = link_to(relay.territory.name, relay_path(relay))
+    - assigned_diagnoses.each do |diagnosis|
+      .ui.segments.horizontal
+        .ui.segment
+          %h4.ui.header
+            = link_to(diagnosis.visit.company_name, diagnosis_relays_path(diagnosis))
+            .sub.header
+              %i.map.marker.alternate.icon
+              - facility = diagnosis.visit.facility
+              .content= facility.readable_locality || facility.city_code
+            .sub.header
+              %i.calendar.icon
+              - date = diagnosis.visit.happened_on || diagnosis.visit.created_at.to_date
+              .content= I18n.l(date, format: '%-d %B %Y')
+        .ui.segment
+          %h4.ui.header
+            = t('relays.needs_for_me')
+            - diagnosis.needs_for(relay).each do |need|
+              .sub.header
+                = need.question_label + ' : '
+                = t("activerecord.attributes.match.statuses.#{need.matches.first.status}")

--- a/app/views/relays/index.html.haml
+++ b/app/views/relays/index.html.haml
@@ -1,32 +1,7 @@
 - meta title: t('.title')
 
-%h2= t('.title')
+%h2.ui.header
+  = t('relays.assigned_diagnoses')
 
 - @relays.each do |relay|
-  - diagnoses = relay.assigned_diagnoses
-  %table.ui.table
-    %thead
-      %tr
-        %th
-          = relay.territory.name
-          %a.ui.right.floated.circular{ href: relay_path(id: relay, format: 'csv') }
-            %i.download.icon.small
-    %tbody
-      - if diagnoses.empty?
-        %tr
-          %td
-            = t('.no_diagnoses')
-      - else
-        - diagnoses.each do |diagnosis|
-          %tr
-            %td.selectable
-              %a{ href: diagnosis_relays_path(diagnosis.id) }
-                .ui.text.medium
-                  = diagnosis.visit.company_description
-                - date = diagnosis.visit.happened_on || diagnosis.visit.created_at.to_date
-                .ui.text.small
-                  %i.calendar.icon
-                  = I18n.l date
-                .ui.text.small
-                  %i.user.icon
-                  = diagnosis.visit.advisor
+  = render partial: 'assigned_diagnoses', locals: { relay: relay }

--- a/app/views/relays/show.html.haml
+++ b/app/views/relays/show.html.haml
@@ -1,0 +1,6 @@
+- meta title: @relay.territory.name
+
+%h2.ui.header
+  = @relay.territory.name
+
+= render partial: 'assigned_diagnoses', locals: { relay: @relay }

--- a/config/locales/views/relays.fr.yml
+++ b/config/locales/views/relays.fr.yml
@@ -1,5 +1,6 @@
 fr:
   relays:
     index:
-      title: Suivi des territoires
-      no_diagnoses: Aucune analyse dont vous êtes référent.
+      title: Suivi des demandes
+    assigned_diagnoses: Demandes reçues en tant que relais local
+    needs_for_me: Besoins me concernant


### PR DESCRIPTION
- dry `Diagnosis.needs_for(relay_or_expert)`
- only display current requests in the dashboard
- add a territory-specific page
