### PR TITLE
Migration: Change Expert<->>Users to Experts<<->>Users

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -2,9 +2,21 @@
 
 ActiveAdmin.register User do
   menu priority: 2
-  permit_params %i[
-    first_name last_name email institution role phone_number is_approved contact_page_order contact_page_role expert_id
-    is_admin password password_confirmation
+
+  permit_params [
+    :first_name,
+    :last_name,
+    :email,
+    :institution,
+    :role,
+    :phone_number,
+    :is_approved,
+    :contact_page_order,
+    :contact_page_role,
+    :is_admin,
+    :password,
+    :password_confirmation,
+    expert_ids: [],
   ]
 
   # Index
@@ -14,7 +26,7 @@ ActiveAdmin.register User do
     id_column
     column :full_name
     column :email
-    column :expert
+    column(:experts) { |user| safe_join(user.experts.map{ |expert| link_to(expert, admin_expert_path(expert)) }, ', '.html_safe) }
     column :created_at
     column :is_approved
     column :sign_in_count
@@ -39,7 +51,7 @@ ActiveAdmin.register User do
     attributes_table do
       row :full_name
       row :institution
-      row :expert
+      row(:experts) { |user| safe_join(user.experts.map{ |expert| link_to(expert, admin_expert_path(expert)) }, ', '.html_safe) }
       row :role
       row :email
       row :phone_number
@@ -82,7 +94,7 @@ ActiveAdmin.register User do
       f.input :first_name
       f.input :last_name
       f.input :institution
-      f.input :expert, as: :ajax_select, data: {
+      f.input :experts, as: :ajax_select, data: {
         url: :admin_experts_path,
         search_fields: [:full_name],
         limit: 999,

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -5,7 +5,7 @@ class Expert < ApplicationRecord
 
   belongs_to :institution
 
-  has_many :users
+  has_and_belongs_to_many :users
   has_many :assistances_experts, dependent: :destroy
   has_many :assistances, through: :assistances_experts
   has_many :matches, through: :assistances_experts

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   has_many :territories, through: :relays
   has_many :visits, foreign_key: 'advisor_id'
   has_many :searches
-  belongs_to :expert
+  has_and_belongs_to_many :experts
 
   validates :first_name, :email, :phone_number, presence: true
 

--- a/config/locales/active_record.fr.yml
+++ b/config/locales/active_record.fr.yml
@@ -96,7 +96,7 @@ fr:
         current_sign_in_ip: IP de connexion
         email: Adresse e-mail
         encrypted_password: Mot de passe chiffré
-        expert: Équipe référents
+        experts: Équipe référents
         first_name: Prénom
         full_name: Prénom et Nom
         institution: Institution

--- a/db/migrate/20180709075825_create_experts_users.rb
+++ b/db/migrate/20180709075825_create_experts_users.rb
@@ -1,0 +1,9 @@
+class CreateExpertsUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :experts_users, id: false do |t|
+      t.belongs_to :expert, index: true
+      t.belongs_to :user, index: true
+    end
+    remove_reference :users, :expert, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_02_092400) do
+ActiveRecord::Schema.define(version: 2018_07_09_075825) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -154,6 +154,13 @@ ActiveRecord::Schema.define(version: 2018_07_02_092400) do
     t.index ["institution_id"], name: "index_experts_on_institution_id"
   end
 
+  create_table "experts_users", id: false, force: :cascade do |t|
+    t.bigint "expert_id"
+    t.bigint "user_id"
+    t.index ["expert_id"], name: "index_experts_users_on_expert_id"
+    t.index ["user_id"], name: "index_experts_users_on_user_id"
+  end
+
   create_table "facilities", force: :cascade do |t|
     t.bigint "company_id"
     t.string "siret"
@@ -259,10 +266,8 @@ ActiveRecord::Schema.define(version: 2018_07_02_092400) do
     t.string "phone_number"
     t.string "institution"
     t.string "role"
-    t.bigint "expert_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["expert_id"], name: "index_users_on_expert_id"
     t.index ["is_approved"], name: "index_users_on_is_approved"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
@@ -298,7 +303,6 @@ ActiveRecord::Schema.define(version: 2018_07_02_092400) do
   add_foreign_key "relays", "users"
   add_foreign_key "searches", "users"
   add_foreign_key "territory_cities", "territories"
-  add_foreign_key "users", "experts"
   add_foreign_key "visits", "contacts", column: "visitee_id"
   add_foreign_key "visits", "facilities"
   add_foreign_key "visits", "users", column: "advisor_id"

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Expert, type: :model do
       is_expected.to have_many(:expert_territories).dependent(:destroy)
       is_expected.to have_many :territories
       is_expected.to have_many :territory_cities
+      is_expected.to have_and_belong_to_many :users
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe User, type: :model do
     it do
       is_expected.to have_many :relays
       is_expected.to have_many :territories
+      is_expected.to have_and_belong_to_many :experts
     end
   end
 


### PR DESCRIPTION
This is actually a workaround: most users (conseillers) are expected to belong to one expert (équipe référent). However, some (référents) have different set of (compétences) for different (territoires), and as of today, exist in duplicate entries in the expert (référents) table. As we want to link a single user (conseiller) to all these experts, we need a many-to-many association.