### PR TITLE
Fix removing the assistances of an expert

### DIFF
--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -7,7 +7,7 @@ class Expert < ApplicationRecord
 
   has_and_belongs_to_many :users
   has_many :assistances_experts, dependent: :destroy
-  has_many :assistances, through: :assistances_experts
+  has_many :assistances, through: :assistances_experts, dependent: :destroy
   has_many :matches, through: :assistances_experts
   has_many :expert_territories, dependent: :destroy
   has_many :territories, through: :expert_territories

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe Expert, type: :model do
       it {
         expect{ expert.assistances = [] }.not_to raise_error
         expect(expert.assistances).to eq []
-        expect(ae).to be_destroyed
       }
     end
   end

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -35,6 +35,24 @@ RSpec.describe Expert, type: :model do
     end
   end
 
+  describe 'associations dependencies' do
+    let(:expert) { create :expert }
+    let(:assistance) { create :assistance }
+    let(:ae) { create :assistance_expert, expert: expert, assistance: assistance }
+
+    before do
+      create :match, assistance_expert: ae
+    end
+
+    context 'when removing an assistance' do
+      it {
+        expect{ expert.assistances = [] }.not_to raise_error
+        expect(expert.assistances).to eq []
+        expect(ae).to be_destroyed
+      }
+    end
+  end
+
   describe 'scopes' do
     describe 'of_city_code' do
       subject { Expert.of_city_code city_code }


### PR DESCRIPTION
There was a modeling issue between Expert, Assistance, and Match; when an AssistanceExpert is destroyed, the Matches using it are correctly nullified. However, when replacing the Assistance of an Expert, the `:through` association using AssistanceExpert was destroyed, but its callback were not.

As per the [docs](http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-has_many): 

> If using with the :through option, the association on the join model must be a belongs_to, and the records which get deleted are the join records, rather than the associated records.

Which, as I understand, means we should specify `dependent: :destroy` on the `has_many: :through` association as well.