### PR TITLE
Dashboard for Experts and Relays

### DIFF
--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -66,7 +66,7 @@ ActiveAdmin.register Expert do
       end
     end
 
-    render partial: 'admin/matches', locals: { matches_relation: Match.of_expert(expert) }
+    render partial: 'admin/matches', locals: { matches_relation: Match.of_relay_or_expert(expert) }
   end
 
   sidebar I18n.t('activerecord.attributes.user.experts'), only: :show do

--- a/app/admin/relay.rb
+++ b/app/admin/relay.rb
@@ -27,6 +27,6 @@ ActiveAdmin.register Relay do
   show do
     default_main_content
 
-    render partial: 'admin/matches', locals: { matches_relation: Match.of_relay(relay) }
+    render partial: 'admin/matches', locals: { matches_relation: Match.of_relay_or_expert(relay) }
   end
 end

--- a/app/controllers/experts_controller.rb
+++ b/app/controllers/experts_controller.rb
@@ -12,7 +12,7 @@ class ExpertsController < ApplicationController
                     diagnosed_needs: [matches: [assistance_expert: :expert]]
 ]
     @diagnosis = Diagnosis.available_for_expert(@expert).includes(associations).find(params[:diagnosis_id])
-    UseCases::UpdateExpertViewedPageAt.perform(diagnosis_id: params[:diagnosis_id].to_i, expert_id: @expert.id)
+    UseCases::UpdateExpertViewedPageAt.perform(diagnosis: @diagnosis, expert: @expert)
     @current_user_diagnosed_needs = @diagnosis.needs_for(@expert)
   end
 

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class MatchesController < ApplicationController
+  skip_before_action :authenticate_user!
+  before_action :authenticate_user!, unless: -> { params[:access_token].present? }
+  before_action :authenticate_expert!, if: -> { params[:access_token].present? }
+
+  def update
+    @match = Match.find(params[:id])
+    check_current_user_access_to(@match)
+    @match.update status: params[:status]
+  end
+end

--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -5,6 +5,8 @@ class NeedsController < ApplicationController
   before_action :authenticate_user!, unless: -> { params[:access_token].present? }
   before_action :authenticate_expert!, if: -> { params[:access_token].present? }
 
+  after_action :mark_expert_viewed, only: :show
+
   def index
     @relays = relays
     @experts = experts
@@ -32,5 +34,11 @@ class NeedsController < ApplicationController
   def experts
     current_user.present? ? current_user.experts.order(:full_name)
       : [current_expert]
+  end
+
+  def mark_expert_viewed
+    experts.each do |expert|
+      UseCases::UpdateExpertViewedPageAt.perform(diagnosis: params[:id].to_i, expert: expert)
+    end
   end
 end

--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class NeedsController < ApplicationController
+  def index
+    @relays = relays
+    @experts = experts
+  end
+
+  def show
+    associations = [visit: [:visitee, :advisor, facility: [:company]],
+                    diagnosed_needs: [matches: [assistance_expert: :expert]]
+    ]
+    @diagnosis = Diagnosis.includes(associations).find(params[:id])
+
+    check_current_user_access_to(@diagnosis)
+
+    needs = @diagnosis.diagnosed_needs.includes(:matches)
+    @current_person_diagnosed_needs = needs.of_relay_or_expert(current_roles)
+  end
+
+  private
+
+  def relays
+    current_user.present? ? current_user.relays.joins(:territory).order('territories.name')
+      : []
+  end
+
+  def experts
+    current_user.present? ? current_user.experts.order(:full_name)
+      : [current_expert]
+  end
+end

--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class NeedsController < ApplicationController
+  skip_before_action :authenticate_user!
+  before_action :authenticate_user!, unless: -> { params[:access_token].present? }
+  before_action :authenticate_expert!, if: -> { params[:access_token].present? }
+
   def index
     @relays = relays
     @experts = experts

--- a/app/helpers/needs_helper.rb
+++ b/app/helpers/needs_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module NeedsHelper
+  def link_to_patch_map(title, match, new_status, css_classes)
+    classes = %w[ui button tiny] + css_classes
+    token = params[:access_token]
+    link_to title, match_path(match.id, access_token: token), data: { remote: true, method: :patch, params: { status: new_status } }, class: classes.join(' ')
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -11,7 +11,7 @@ class Contact < ApplicationRecord
 
   scope :ordered_by_names, (-> { order(:full_name) })
 
-  def can_be_viewed_by?(user)
-    visits.any? { |visit| visit.can_be_viewed_by?(user) }
+  def can_be_viewed_by?(role)
+    visits.any? { |visit| visit.can_be_viewed_by?(role) }
   end
 end

--- a/app/models/diagnosed_need.rb
+++ b/app/models/diagnosed_need.rb
@@ -16,6 +16,7 @@ class DiagnosedNeed < ApplicationRecord
   scope :of_relay, (lambda do |relay|
     joins(:matches).merge(Match.of_relay(relay))
   end)
+  scope :of_relay_or_expert, (-> (relay_or_expert) { joins(:matches).merge(Match.of_relay_or_expert(relay_or_expert)) })
   scope :with_at_least_one_expert_done, (lambda do
     where(id: Match.with_status(:done).select(:diagnosed_need_id))
   end)

--- a/app/models/diagnosed_need.rb
+++ b/app/models/diagnosed_need.rb
@@ -20,7 +20,11 @@ class DiagnosedNeed < ApplicationRecord
     where(id: Match.with_status(:done).select(:diagnosed_need_id))
   end)
 
-  def can_be_viewed_by?(user)
-    diagnosis.visit.can_be_viewed_by?(user) || matches.any?{ |match| match.can_be_viewed_by?(user) }
+  def can_be_viewed_by?(role)
+    diagnosis.visit.can_be_viewed_by?(role) || belongs_to_relay_or_expert?(role)
+  end
+
+  def belongs_to_relay_or_expert?(role)
+    matches.any?{ |match| match.belongs_to_relay_or_expert?(role) }
   end
 end

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -26,6 +26,15 @@ class Diagnosis < ApplicationRecord
       .where(diagnosed_needs: { matches: { assistance_expert: { experts: { id: expert.id } } } })
   end)
 
+  scope :of_relay_or_expert, (lambda do |relay_or_expert|
+    only_active
+      .includes(visit: [facility: :company])
+      .joins(:diagnosed_needs)
+      .merge(DiagnosedNeed.of_relay_or_expert(relay_or_expert))
+      .order('visits.happened_on desc', 'visits.created_at desc')
+      .distinct
+  end)
+
   scope :after_step, (-> (minimum_step) { where('step >= ?', minimum_step) })
 
   scope :only_active, (-> { where(archived_at: nil) })

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -44,8 +44,8 @@ class Diagnosis < ApplicationRecord
     I18n.l created_at.to_date
   end
 
-  def can_be_viewed_by?(user)
-    visit.can_be_viewed_by?(user) || diagnosed_needs.any?{ |need| need.can_be_viewed_by?(user) }
+  def can_be_viewed_by?(role)
+    visit.can_be_viewed_by?(role) || diagnosed_needs.any?{ |need| need.can_be_viewed_by?(role) }
   end
 
   def needs_for(relay_or_expert)

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -43,19 +43,19 @@ class Match < ApplicationRecord
   end
 
   def person
-    assistance_expert&.expert || relay&.user
+    expert || relay&.user
   end
 
   def person_full_name
     person&.full_name || expert_full_name
   end
 
-  def belongs_to_user?(user)
-    relay&.user == user || expert&.users&.include?(user)
+  def belongs_to_relay_or_expert?(role)
+    role.present? && (expert == role || relay == role)
   end
 
-  def can_be_viewed_by?(user)
-    belongs_to_user?(user)
+  def can_be_viewed_by?(role)
+    belongs_to_relay_or_expert?(role)
   end
 
   private

--- a/app/models/use_cases/update_expert_viewed_page_at.rb
+++ b/app/models/use_cases/update_expert_viewed_page_at.rb
@@ -5,7 +5,7 @@ module UseCases
     class << self
       def perform(diagnosis_id:, expert_id:)
         matches = Match.of_diagnoses(diagnosis_id)
-          .of_expert(expert_id)
+          .of_relay_or_expert(expert_id)
           .not_viewed
         matches.update_all expert_viewed_page_at: Time.zone.now
       end

--- a/app/models/use_cases/update_expert_viewed_page_at.rb
+++ b/app/models/use_cases/update_expert_viewed_page_at.rb
@@ -3,9 +3,9 @@
 module UseCases
   class UpdateExpertViewedPageAt
     class << self
-      def perform(diagnosis_id:, expert_id:)
-        matches = Match.of_diagnoses(diagnosis_id)
-          .of_relay_or_expert(expert_id)
+      def perform(diagnosis:, expert:)
+        matches = Match.of_diagnoses(diagnosis)
+          .of_relay_or_expert(expert)
           .not_viewed
         matches.update_all expert_viewed_page_at: Time.zone.now
       end

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -28,7 +28,7 @@ class Visit < ApplicationRecord
     facility.to_s
   end
 
-  def can_be_viewed_by?(user)
-    advisor == user
+  def can_be_viewed_by?(role)
+    role.present? && advisor == role
   end
 end

--- a/app/views/admin/_matches.html.arb
+++ b/app/views/admin/_matches.html.arb
@@ -36,9 +36,10 @@ panel "#{I18n.t('activerecord.models.match.other')} (#{matches_relation.length})
       diagnosis_id = match.diagnosed_need.diagnosis_id
       if match.assistance_expert
         access_token = match.assistance_expert.expert.access_token
-        link_to 'Page Référent', diagnosis_experts_path(diagnosis_id: diagnosis_id, access_token: access_token)
-      else
-        link_to 'Page Référent', diagnosis_relays_path(diagnosis_id: diagnosis_id, relay_id: match.relay_id)
+        link_to 'Page Référent', besoin_path(diagnosis_id, access_token: access_token)
+      elsif match.relay
+        user = match.relay.user
+        link_to t('active_admin.user.impersonate', name: user.full_name), impersonate_engine.impersonate_user_path(user)
       end
     end
   end

--- a/app/views/matches/update.js.erb
+++ b/app/views/matches/update.js.erb
@@ -1,0 +1,10 @@
+<%- locals = { match: @match } %>
+
+var match = "<%= j render(partial: 'needs/match', locals: locals) %>";
+document.getElementById('match-line-<%= @match.id %>-global').innerHTML = match;
+
+var matchOwner = "<%= j render(partial: 'needs/match_for_need_owner', locals: locals) %>";
+document.getElementById('match-line-<%= @match.id %>-owner').innerHTML = matchOwner;
+
+var expertButtons = "<%= j render(partial: 'needs/expert_buttons', locals: locals) %>";
+document.getElementById('expert-buttons-line-<%= @match.id %>').innerHTML = expertButtons;

--- a/app/views/needs/_assigned_diagnoses.html.haml
+++ b/app/views/needs/_assigned_diagnoses.html.haml
@@ -1,0 +1,28 @@
+- assigned_diagnoses = Diagnosis.of_relay_or_expert(relay_or_expert)
+- if assigned_diagnoses.present?
+  .ui.segments
+    %h3.ui.segment.block.header
+      = title
+    - assigned_diagnoses.each do |diagnosis|
+      .ui.segment
+        .ui.equal.width.grid
+          .row.stretched
+            .column
+              %h4.ui.header
+                = link_to(diagnosis.visit.company_name, besoin_path(diagnosis, params.permit(:access_token)))
+                .sub.header
+                  %i.map.marker.alternate.icon
+                  - facility = diagnosis.visit.facility
+                  .content= facility.readable_locality || facility.city_code
+                .sub.header
+                  %i.calendar.icon
+                  - date = diagnosis.visit.happened_on || diagnosis.visit.created_at.to_date
+                  .content= I18n.l(date, format: '%-d %B %Y')
+            .column
+              %h4.ui.header
+                = t('relays.needs_for_me')
+                - diagnosis.diagnosed_needs.of_relay_or_expert(relay_or_expert).each do |need|
+                  .sub.header
+                    = need.question_label + ' : '
+                    - matches = need.matches.of_relay_or_expert(relay_or_expert)
+                    = t("activerecord.attributes.match.statuses.#{matches.first.status}")

--- a/app/views/needs/_expert_buttons.html.haml
+++ b/app/views/needs/_expert_buttons.html.haml
@@ -1,0 +1,19 @@
+%td.expert-owner-button-cell{ colspan: 3 }
+  - if match.status_quo?
+    = link_to_patch_map t('.i_take_care'), match, :taking_care, %w[green]
+    = link_to_patch_map t('.not_for_me'), match, :not_for_me, %w[red]
+
+  - elsif match.status_taking_care?
+    = link_to_patch_map t('.dont_take_care_any_more'), match, :quo, %w[basic]
+    = link_to_patch_map t('.done'), match, :done, %w[green]
+    = link_to_patch_map t('.not_for_me'), match, :not_for_me, %w[red]
+
+  - elsif match.status_done?
+    = link_to_patch_map t('.dont_take_care_any_more'), match, :quo, %w[basic]
+    = link_to_patch_map t('.ongoing'), match, :taking_care, %w[basic]
+    = link_to_patch_map t('.not_for_me'), match, :not_for_me, %w[basic red]
+
+  - elsif match.status_not_for_me?
+    = link_to_patch_map t('.dont_take_care_any_more'), match, :quo, %w[basic]
+    = link_to_patch_map t('.ongoing'), match, :taking_care, %w[basic]
+    = link_to_patch_map t('.done'), match, :done, %w[basic green]

--- a/app/views/needs/_match.html.haml
+++ b/app/views/needs/_match.html.haml
@@ -1,0 +1,27 @@
+%td.expert-width
+  %strong= match.person_full_name
+  %br
+    - person = match.person
+    - if person
+      - if person.phone_number.present?
+        = person.phone_number
+        %br
+      = mail_to person.email
+%td
+  #{t('activerecord.models.institution.one')} : #{match.expert_institution_name}
+  - if match.assistance_title
+    %br
+    #{t('activerecord.models.assistance.one')} : #{match.assistance_title}
+%td.expert-status-cell
+  - if match.status_quo?
+    %i.icon.clock
+    = t('.waiting_for_answer')
+  - elsif match.status_taking_care?
+    %i.icon.checkmark
+    = t('.he_takes_care')
+  - elsif match.status_done?
+    %i.icon.checkmark
+    = t('.done')
+  - elsif match.status_not_for_me?
+    %i.icon.remove
+    = t('.not_for_him')

--- a/app/views/needs/_match_for_need_owner.html.haml
+++ b/app/views/needs/_match_for_need_owner.html.haml
@@ -1,0 +1,19 @@
+%td.text.tiny.bold{ colspan: 1 }
+  = t('.my_status')
+  = match.person_full_name
+%td.expert-owner-status-cell{ colspan: 2 }
+  - if match.status_quo?
+    %i.icon.clock
+    = t('.waiting_for_answer')
+
+  - elsif match.status_taking_care?
+    %i.icon.checkmark
+    = t('.ongoing')
+
+  - elsif match.status_done?
+    %i.icon.checkmark
+    = t('.done')
+
+  - elsif match.status_not_for_me?
+    %i.icon.remove
+    = t('.not_for_me')

--- a/app/views/needs/index.html.haml
+++ b/app/views/needs/index.html.haml
@@ -1,0 +1,12 @@
+- meta title: t('.title')
+
+- @relays.each do |relay|
+  %h2.ui.header= relay.territory.name
+  // Display info about Relay/Territory : all the diagnostics, etc.
+  = render partial: 'assigned_diagnoses', locals: { relay_or_expert: relay, title: "Demandes pour le relais local" }
+
+- @experts.each do |expert|
+  %h2.ui.header= expert.full_name
+  = render partial: 'team', locals: { expert: expert, user: current_user }
+  // Display info about Expert: the team, the old diagnoses, etc.
+  = render partial: 'assigned_diagnoses', locals: { relay_or_expert: expert, title: "Demandes pour le référent" }

--- a/app/views/needs/show.html.haml
+++ b/app/views/needs/show.html.haml
@@ -1,0 +1,87 @@
+- meta title: t('.title')
+
+#experts-diagnosis
+  .ui.info.message
+    .text.tiny.justified
+      = t('.introduction_html')
+
+  %table.ui.table
+    %tbody
+      %tr
+        %td
+          %h2.ui.header
+            = @diagnosis.visit.facility.company.name_short
+            .sub.header
+              = @diagnosis.creation_date_localized
+        %td.collapsing
+          .ui.middle.aligned.list
+            .item
+              .middle.aligned.content
+                %h4.ui.header.disabled
+                  = t('.diagnosed_needs', count: @diagnosis.diagnosed_needs.count)
+            .item
+              .middle.aligned.content
+                %h4.ui.header.disabled
+                  = t('.matches', count: diagnosis_matches_count)
+
+  - visitee = @diagnosis.visit.visitee
+  - advisor = @diagnosis.visit.advisor
+
+  = render partial: 'people/person', locals: { person: visitee, subtitle: t('.company_contact_subtitle') }
+  = render partial: 'people/person', locals: { person: advisor, subtitle: t('.advisor_contact_subtitle') }
+
+  %h2= t('.my_needs_summary_subtitle')
+  - @current_person_diagnosed_needs.each do |diagnosed_need|
+    %table.ui.celled.table
+      %thead
+        %tr
+          %th{ colspan: 3 }= diagnosed_need.question_label
+      %tbody
+        - if diagnosed_need.content.present?
+          %tr
+            %td{ colspan: 3 }
+              .ui.form
+                .field
+                  %label= t('.diagnosed_needs_content_label')
+                  = diagnosed_need.content
+
+        - diagnosed_need.matches.each do |match|
+          - id = "match-line-#{match.id}-owner"
+          %tr.small.text.ui.tiny.table{ id: id }
+            - locals = { match: match }
+            = render partial: 'match_for_need_owner', locals: locals
+
+          %tr.small.text.ui.tiny.table{ id: "expert-buttons-line-#{match.id}" }
+            - locals = { match: match }
+            = render partial: 'expert_buttons', locals: locals
+
+  %h2= t('.need_contacts_summary_subtitle')
+  - @diagnosis.diagnosed_needs.each do |diagnosed_need|
+    %table.ui.celled.table
+      %thead
+        %tr
+          %th{ colspan: 3 }= diagnosed_need.question_label
+      %tbody
+        - if diagnosed_need.content.present?
+          %tr
+            %td{ colspan: 3 }
+              .ui.form
+                .field
+                  %label= t('.diagnosed_needs_content_label')
+                  = diagnosed_need.content
+        - if diagnosed_need.matches.empty?
+          %tr.small.text.ui.tiny.table{ colspan: 2 }
+            %td= t('.zero_contacted_expert')
+        - else
+          - diagnosed_need.matches.each do |match|
+            - id = "match-line-#{match.id}-global"
+            %tr.small.text.ui.tiny.table{ id: id }
+              - locals = { match: match }
+              = render partial: 'match', locals: locals
+
+  - if @diagnosis.content
+    %h2= t('.diagnosis_content_subtitle')
+    .ui.segment.shadow-less
+      .ui.form
+        .field
+          = @diagnosis.content

--- a/config/locales/views/needs.fr.yml
+++ b/config/locales/views/needs.fr.yml
@@ -1,0 +1,45 @@
+---
+fr:
+  needs:
+    expert_buttons:
+      done: Besoin résolu
+      dont_take_care_any_more: Ne plus s’en charger
+      i_take_care: Je m’en charge !
+      not_for_me: Ce n’est pas pour moi
+      ongoing: En cours de résolution
+    index:
+      title: Besoins
+    match:
+      done: Besoin résolu
+      he_takes_care: S’en charge
+      not_for_him: Ce n’est pas pour lui
+      waiting_for_answer: En attente d’une réponse du référent
+    match_for_need_owner:
+      done: Besoin résolu
+      my_status: 'Mon statut sur ce besoin :'
+      not_for_me: Ce n’est pas pour moi
+      ongoing: En cours de résolution
+      waiting_for_answer: En attente de votre réponse
+    show:
+      advisor_contact_subtitle: Conseiller ayant effectué l’analyse des besoins de l’entreprise
+      company_contact_subtitle: Contact rencontré au sein de l’entreprise
+      diagnosed_needs:
+        one: 1 besoin identifié
+        other: "%{count} besoins identifiés"
+        zero: 0 besoin identifié
+      diagnosed_needs_content_label: 'Les informations complémentaires concernant ce besoin :'
+      diagnosis_content_subtitle: Informations générales
+      introduction_html: |
+        L’entreprise ci-dessous a exprimé des besoins qui correspondent à votre compétence. Pour prendre en charge ces
+        besoins, vous pouvez recontacter l’entreprise ou le conseiller en utilisant les informations de contact
+        disponibles ci-dessous.<br>
+        N’oubliez pas d’indiquer votre prise en charge des besoins pour que le conseiller et autres référents puissent
+        être mis au courant de votre avancée.
+      matches:
+        one: 1 mise en relation
+        other: "%{count} mises en relation"
+        zero: 0 mise en relation
+      my_needs_summary_subtitle: Demandes me concernant
+      need_contacts_summary_subtitle: Référents contactés classés par besoin
+      title: Récapitulatif
+      zero_contacted_expert: Aucun référent n’a été contacté pour ce besoin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :besoins, controller: 'needs', only: %i[index show]
+
   namespace :api do
     resources :diagnoses, only: %i[show create update] do
       resources :diagnosed_needs, only: %i[index] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,8 @@ Rails.application.routes.draw do
 
   resources :besoins, controller: 'needs', only: %i[index show]
 
+  resources :matches, only: %i[update]
+
   namespace :api do
     resources :diagnoses, only: %i[show create update] do
       resources :diagnosed_needs, only: %i[index] do

--- a/spec/controllers/experts_controller_spec.rb
+++ b/spec/controllers/experts_controller_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe ExpertsController, type: :controller do
 
       before do
         allow(UseCases::UpdateExpertViewedPageAt).to receive(:perform).with(
-          diagnosis_id: diagnosis.id,
-          expert_id: expert.id
+          diagnosis: diagnosis,
+          expert: expert
         )
       end
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -12,36 +12,6 @@ RSpec.describe Match, type: :model do
     end
   end
 
-  describe '#can_be_viewed_by?' do
-    subject { match.can_be_viewed_by?(user) }
-
-    let(:match) { create :match }
-    let(:user) { create :user }
-    let(:expert) { create :expert }
-    let(:relay) { create :relay }
-
-    before do
-      user.relays = [relay]
-      user.experts = [expert]
-    end
-
-    context 'user is unrelated' do
-      it { is_expected.to be_falsey }
-    end
-
-    context 'user is relay' do
-      before { match.relay = relay }
-
-      it { is_expected.to be_truthy }
-    end
-
-    context 'user is expert' do
-      before { match.expert = expert }
-
-      it { is_expected.to be_truthy }
-    end
-  end
-
   describe 'audited' do
     context 'create' do
       it { expect { create :match }.to change(Audited::Audit, :count).by 1 }

--- a/spec/models/use_cases/update_expert_viewed_page_at_spec.rb
+++ b/spec/models/use_cases/update_expert_viewed_page_at_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe UseCases::UpdateExpertViewedPageAt do
   describe 'perform' do
-    subject(:perform_use_case) { described_class.perform diagnosis_id: diagnosis.id, expert_id: expert.id }
+    subject(:perform_use_case) { described_class.perform diagnosis: diagnosis, expert: expert }
 
     let(:diagnosis) { create :diagnosis }
     let(:diagnosed_need) { create :diagnosed_need, diagnosis: diagnosis }


### PR DESCRIPTION
Display all the needs in a single place. Refactor from the experts_controller and relays_controller.

* [x] some tests and cleanup are missing

Some redesign would be needed, but it’s currently the same UI as what was done in relays_controller and experts_controller.

This does not actually activate the view, but puts everything in place.