### PR TITLE
Allow deleting a user with a search history

### DIFF
--- a/app/helpers/companies_helper.rb
+++ b/app/helpers/companies_helper.rb
@@ -7,7 +7,7 @@ module CompaniesHelper
 
   def last_searches
     array = []
-    searches = Search.of_user(current_user).recent
+    searches = current_user.searches.recent
     searches.each do |search|
       if !array.map(&:query).include?(search.query)
         array << search

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -5,7 +5,6 @@ class Search < ApplicationRecord
 
   validates :user, presence: true
 
-  scope :of_user, (-> (user) { where(user: user) })
   scope :recent, (-> { order(created_at: :desc).limit(30) })
 
   def summary

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   has_many :relays
   has_many :territories, through: :relays
   has_many :visits, foreign_key: 'advisor_id'
-  has_many :searches
+  has_many :searches, dependent: :destroy
   has_and_belongs_to_many :experts
 
   validates :full_name, :email, :phone_number, presence: true

--- a/spec/models/relay_spec.rb
+++ b/spec/models/relay_spec.rb
@@ -37,10 +37,9 @@ RSpec.describe Relay, type: :model do
 
   describe 'associations dependencies' do
     let(:relay) { create :relay }
-    let(:match) { create :match }
 
     context 'with an assigned match' do
-      before { match.relay = relay }
+      before { create :match, relay: relay }
 
       it {
         expect{ relay.destroy! }.not_to raise_error

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -12,17 +12,6 @@ RSpec.describe Search, type: :model do
   end
 
   describe 'scopes' do
-    describe 'of_user' do
-      subject { Search.of_user user }
-
-      let(:user) { build :user }
-      let!(:search) { create :search, user: user }
-
-      before { create :search }
-
-      it { is_expected.to eq [search] }
-    end
-
     describe 'recent' do
       subject { Search.recent }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe 'associations dependencies' do
+    let(:user) { create :user }
+
+    context 'with a search history' do
+      before { create :search, user: user }
+
+      it {
+        expect{ user.destroy! }.not_to raise_error
+      }
+    end
+  end
+
   describe 'scopes' do
     describe 'with_contact_page_order' do
       it do


### PR DESCRIPTION
On the other hand, it’s not possible (yet?) to delete a user who made a visit.

Additionally, cleanup a similar test in Relay and remove a useless scope in Search.