### PR TITLE
Add interview questions ordering

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,6 +5,8 @@ class Category < ApplicationRecord
 
   validates :label, presence: true, uniqueness: true
 
+  default_scope { order(:interview_sort_order, :id) }
+
   def to_s
     label
   end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -7,6 +7,8 @@ class Question < ApplicationRecord
 
   validates :category, presence: true
 
+  default_scope { order(:interview_sort_order, :id) }
+
   def to_s
     label
   end

--- a/db/migrate/20180830154712_add_interview_sort_order.rb
+++ b/db/migrate/20180830154712_add_interview_sort_order.rb
@@ -1,0 +1,6 @@
+class AddInterviewSortOrder < ActiveRecord::Migration[5.2]
+  def change
+    add_column :questions, :interview_sort_order, :integer
+    add_column :categories, :interview_sort_order, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_23_155356) do
+ActiveRecord::Schema.define(version: 2018_08_30_154712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 2018_07_23_155356) do
     t.string "label"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "interview_sort_order"
   end
 
   create_table "companies", id: :serial, force: :cascade do |t|
@@ -208,6 +209,7 @@ ActiveRecord::Schema.define(version: 2018_07_23_155356) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "category_id"
+    t.integer "interview_sort_order"
     t.index ["category_id"], name: "index_questions_on_category_id"
   end
 


### PR DESCRIPTION
Add a “order” attribute to categories/questions and use it as the default sort order.

This is not used yet in the UI, as the “GetStep2Data” methods order questions manually, by `category_id` and `id`. However, this should just work when the step2 is rewritten in pure Rails. (#184)