### PR TITLE
Assign the @categories variable before rendering step2

### DIFF
--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -38,6 +38,7 @@ class DiagnosesController < ApplicationController
       redirect_to action: :step3, id: @diagnosis
     else
       flash.alert = @diagnosis.errors.full_messages.to_sentence
+      @categories = Category.all.includes(:questions)
       render action: :step2
     end
   end


### PR DESCRIPTION
Whenever updating the needs fails and we render the step 2 again, we need to reset all the variables.