### PR TITLE
Improve ActiveAdmin operations for Visit/Diagnosis

### DIFF
--- a/app/admin/diagnosis.rb
+++ b/app/admin/diagnosis.rb
@@ -2,8 +2,7 @@
 
 ActiveAdmin.register Diagnosis do
   menu priority: 7
-  actions :index, :show
-  includes visit: [facility: :company]
+  includes visit: [:advisor, facility: :company]
 
   filter :visit, collection: -> { Visit.includes(facility: :company).joins(facility: :company).order('companies.name') }
   filter :content
@@ -11,4 +10,24 @@ ActiveAdmin.register Diagnosis do
   filter :updated_at
   filter :archived_at
   filter :step
+
+  show do
+    attributes_table do
+      row :visit
+      row :created_at
+      row :updated_at
+      row :archived_at
+      row(:advisor) { |d| d.visit.advisor }
+      row :step
+      row :description
+    end
+    panel I18n.t('activerecord.models.diagnosed_need.other') do
+      table_for diagnosis.diagnosed_needs do
+        column(:id) { |n| link_to(n.id, admin_diagnosed_need_path(n)) }
+        column(:category) { |n| n.question&.category&.label }
+        column :question_label
+        column(:content) { |n| link_to(n.content, admin_diagnosed_need_path(n)) }
+      end
+    end
+  end
 end

--- a/app/admin/match.rb
+++ b/app/admin/match.rb
@@ -2,9 +2,10 @@
 
 ActiveAdmin.register Match do
   menu parent: :diagnoses, priority: 2
-  actions :index, :show, :edit, :update
   permit_params :diagnosed_need_id, :assistances_experts_id, :relay_id, :status
-  includes diagnosed_need: [diagnosis: [visit: :advisor]]
+  includes diagnosed_need: [diagnosis: [visit: [:advisor, facility: :company]]]
+  includes assistance_expert: :expert
+  includes :relay
 
   index do
     selectable_column

--- a/app/admin/visit.rb
+++ b/app/admin/visit.rb
@@ -2,7 +2,6 @@
 
 ActiveAdmin.register Visit do
   menu parent: :diagnoses, priority: 3
-  actions :index, :show
   permit_params :advisor_id, :visitee_id, :happened_on, :company_id, :facility_id
   includes :advisor, :visitee, :facility, facility: :company
 
@@ -14,4 +13,16 @@ ActiveAdmin.register Visit do
   filter :happened_on
   filter :created_at
   filter :updated_at
+
+  show do
+    attributes_table do
+      row :advisor
+      row :visitee
+      row :happened_on
+      row :created_at
+      row :updated_at
+      row :facility
+      row :diagnosis
+    end
+  end
 end

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -5,7 +5,7 @@ class Visit < ApplicationRecord
   belongs_to :visitee, class_name: 'Contact'
   belongs_to :facility
 
-  has_one :diagnosis
+  has_one :diagnosis, dependent: :destroy
   accepts_nested_attributes_for :visitee
 
   validates :advisor, :facility, presence: true


### PR DESCRIPTION
Allow editing and deleting visits and diagnoses from ActiveAdmin, properly cascade deletions, and display diagnosed needs from the Diagnosis details view.