### PR TITLE
Change the default scope ordering of matches

### DIFF
--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -66,7 +66,7 @@ ActiveAdmin.register Expert do
       end
     end
 
-    render partial: 'admin/matches', locals: { matches_relation: Match.of_relay_or_expert(expert) }
+    render partial: 'admin/matches', locals: { matches_relation: expert.matches }
   end
 
   sidebar I18n.t('activerecord.attributes.user.experts'), only: :show do

--- a/app/admin/relay.rb
+++ b/app/admin/relay.rb
@@ -27,6 +27,6 @@ ActiveAdmin.register Relay do
   show do
     default_main_content
 
-    render partial: 'admin/matches', locals: { matches_relation: Match.of_relay_or_expert(relay) }
+    render partial: 'admin/matches', locals: { matches_relation: relay.matches }
   end
 end

--- a/app/models/assistance_expert.rb
+++ b/app/models/assistance_expert.rb
@@ -3,7 +3,7 @@
 class AssistanceExpert < ApplicationRecord
   belongs_to :assistance
   belongs_to :expert
-  has_many :matches, foreign_key: :assistances_experts_id, dependent: :nullify
+  has_many :matches, -> { ordered_by_status }, foreign_key: :assistances_experts_id, dependent: :nullify
 
   scope :of_city_code, (-> (city_code) { joins(:expert).merge(Expert.of_city_code(city_code)) })
   scope :of_naf_code, (-> (naf_code) { joins(expert: :institution).merge(Institution.of_naf_code(naf_code)) })

--- a/app/models/diagnosed_need.rb
+++ b/app/models/diagnosed_need.rb
@@ -4,7 +4,7 @@ class DiagnosedNeed < ApplicationRecord
   belongs_to :diagnosis
   belongs_to :question
 
-  has_many :matches, dependent: :destroy
+  has_many :matches, -> { ordered_by_status }, dependent: :destroy
 
   validates :diagnosis, presence: true
   validates :question, uniqueness: { scope: :diagnosis_id, allow_nil: true }

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -9,7 +9,7 @@ class Diagnosis < ApplicationRecord
   has_many :diagnosed_needs, dependent: :destroy
   accepts_nested_attributes_for :diagnosed_needs, allow_destroy: true
   has_many :questions, through: :diagnosed_needs
-  has_many :matches, through: :diagnosed_needs
+  has_many :matches, -> { ordered_by_status }, through: :diagnosed_needs
 
   validates :visit, presence: true
   accepts_nested_attributes_for :visit

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -8,7 +8,7 @@ class Expert < ApplicationRecord
   has_and_belongs_to_many :users
   has_many :assistances_experts, dependent: :destroy
   has_many :assistances, through: :assistances_experts, dependent: :destroy
-  has_many :matches, through: :assistances_experts
+  has_many :matches, -> { ordered_by_status }, through: :assistances_experts
   has_many :expert_territories, dependent: :destroy
   has_many :territories, through: :expert_territories
   has_many :territory_cities, through: :territories

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -17,6 +17,8 @@ class Match < ApplicationRecord
   after_update :update_taken_care_of_at
   after_update :update_closed_at
 
+  scope :ordered_by_status, -> { order(status: :desc, id: :asc) }
+
   scope :not_viewed, (-> { where(expert_viewed_page_at: nil) })
 
   scope :of_diagnoses, (lambda do |diagnoses|

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -3,7 +3,7 @@
 class Relay < ApplicationRecord
   belongs_to :territory
   belongs_to :user
-  has_many :matches, dependent: :nullify
+  has_many :matches, -> { ordered_by_status }, dependent: :nullify
 
   validates :territory, :user, presence: true
   validates :territory, uniqueness: { scope: :user }

--- a/app/views/admin/_matches.html.arb
+++ b/app/views/admin/_matches.html.arb
@@ -2,8 +2,7 @@ panel "#{I18n.t('activerecord.models.match.other')} (#{matches_relation.length})
   table_for matches_relation
     .includes(diagnosed_need: [diagnosis: [visit: [facility: :company]]])
     .includes(diagnosed_need: [diagnosis: [visit: :advisor]])
-    .includes(:expert)
-    .order(created_at: :desc) do
+    .includes(:expert) do
     column(:id) do |match|
       link_to(match.id, admin_match_path(match))
     end

--- a/db/migrate/20180920101754_add_matches_status_index.rb
+++ b/db/migrate/20180920101754_add_matches_status_index.rb
@@ -1,0 +1,5 @@
+class AddMatchesStatusIndex < ActiveRecord::Migration[5.2]
+  def change
+    add_index(:matches, :status)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_13_145542) do
+ActiveRecord::Schema.define(version: 2018_09_20_101754) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -198,6 +198,7 @@ ActiveRecord::Schema.define(version: 2018_09_13_145542) do
     t.index ["assistances_experts_id"], name: "index_matches_on_assistances_experts_id"
     t.index ["diagnosed_need_id"], name: "index_matches_on_diagnosed_need_id"
     t.index ["relay_id"], name: "index_matches_on_relay_id"
+    t.index ["status"], name: "index_matches_on_status"
   end
 
   create_table "questions", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
This is using the (implementation detail) value of the status enum; but it’s a start.