### PR TITLE
 Refactor the with_no_one_in_charge scope

### DIFF
--- a/app/models/diagnosed_need.rb
+++ b/app/models/diagnosed_need.rb
@@ -16,6 +16,8 @@ class DiagnosedNeed < ApplicationRecord
   scope :of_relay_or_expert, (-> (relay_or_expert) { joins(:matches).merge(Match.of_relay_or_expert(relay_or_expert)) })
   scope :with_at_least_one_expert_done, -> { joins(:matches).where(matches: { status: :done }).distinct }
   scope :with_no_one_in_charge, -> { where.not(matches: Match.where(status: [:done, :taking_care])) }
+  scope :done, -> { where(matches: Match.where(status: [:done])) }
+  scope :being_taken_care_of, -> { where(matches: Match.where(status: [:taking_care])).where.not(id: done) }
   scope :made_in, (lambda do |date_range|
     joins(diagnosis: :visit)
       .where(diagnoses: { visits: { happened_on: date_range } })

--- a/app/models/diagnosed_need.rb
+++ b/app/models/diagnosed_need.rb
@@ -15,6 +15,7 @@ class DiagnosedNeed < ApplicationRecord
   scope :of_question, (-> (question) { where(question: question) })
   scope :of_relay_or_expert, (-> (relay_or_expert) { joins(:matches).merge(Match.of_relay_or_expert(relay_or_expert)) })
   scope :with_at_least_one_expert_done, -> { joins(:matches).where(matches: { status: :done }).distinct }
+  scope :with_no_one_in_charge, -> { where.not(matches: Match.where(status: [:done, :taking_care])) }
   scope :made_in, (lambda do |date_range|
     joins(diagnosis: :visit)
       .where(diagnoses: { visits: { happened_on: date_range } })

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -27,10 +27,6 @@ class Match < ApplicationRecord
   scope :with_status, (-> (status) { where(status: status) })
   scope :updated_more_than_five_days_ago, (-> { where('updated_at < ?', 5.days.ago) })
   scope :needing_taking_care_update, (-> { with_status(:taking_care).updated_more_than_five_days_ago })
-  scope :with_no_one_in_charge, (lambda do
-    ids = Match.select(:diagnosed_need_id).group(:diagnosed_need_id).having('SUM(status) = 0')
-    where(diagnosed_need_id: ids).updated_more_than_five_days_ago
-  end)
 
   scope :in_territory, (-> (territory) { of_diagnoses(Diagnosis.in_territory(territory)) })
   scope :of_facilities, (-> (facilities) { of_diagnoses(Diagnosis.of_facilities(facilities)) })

--- a/app/services/expert_reminder_service.rb
+++ b/app/services/expert_reminder_service.rb
@@ -31,17 +31,18 @@ class ExpertReminderService
     end
 
     def matches_with_no_one_in_charge
-      Match.includes(assistance_expert: :expert).with_no_one_in_charge.each do |match|
-        if !match.assistance_expert
-          next
-        end
+      DiagnosedNeed.with_no_one_in_charge.each do |diagnosed_need|
+        diagnosed_need.matches.each do |match|
+          if !match.assistance_expert
+            next
+          end
 
-        expert_id = match.assistance_expert.expert_id
-
-        if !@experts_hash[expert_id]
-          init_expert_hash(match)
+          expert_id = match.assistance_expert.expert_id
+          if !@experts_hash[expert_id]
+            init_expert_hash(match)
+          end
+          @experts_hash[expert_id][:matches_hash][:with_no_one_in_charge] << match
         end
-        @experts_hash[expert_id][:matches_hash][:with_no_one_in_charge] << match
       end
     end
 

--- a/spec/models/diagnosed_need_spec.rb
+++ b/spec/models/diagnosed_need_spec.rb
@@ -88,5 +88,37 @@ RSpec.describe DiagnosedNeed, type: :model do
         it { is_expected.to eq [diagnosed_need] }
       end
     end
+
+    describe 'with_no_one_in_charge' do
+      subject { DiagnosedNeed.with_no_one_in_charge }
+
+      let(:abandoned_diagnosed_need) { create :diagnosed_need }
+      let(:answered_diagnosed_need) { create :diagnosed_need }
+      let(:other_answered_diagnosed_need) { create :diagnosed_need }
+
+      before do
+        create_list :match,
+          2,
+          status: :quo,
+          diagnosed_need: abandoned_diagnosed_need
+        create :match,
+          status: :quo,
+          diagnosed_need: answered_diagnosed_need
+
+        create :match,
+          status: :taking_care,
+          diagnosed_need: answered_diagnosed_need
+
+        create :match,
+          status: :done,
+          diagnosed_need: other_answered_diagnosed_need
+
+        create :match,
+          status: :not_for_me,
+          diagnosed_need: other_answered_diagnosed_need
+      end
+
+      it { is_expected.to eq [abandoned_diagnosed_need] }
+    end
   end
 end

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -206,46 +206,6 @@ RSpec.describe Match, type: :model do
 
       it { is_expected.to eq [match_needing_update] }
     end
-
-    describe 'with_no_one_in_charge' do
-      subject { Match.with_no_one_in_charge }
-
-      let(:abandoned_diagnosed_need) { create :diagnosed_need }
-      let(:answered_diagnosed_need) { create :diagnosed_need }
-      let(:other_answered_diagnosed_need) { create :diagnosed_need }
-
-      let(:matches_with_no_one_in_charge) do
-        create_list :match,
-          2,
-          status: :quo,
-          diagnosed_need: abandoned_diagnosed_need,
-          updated_at: 6.days.ago
-      end
-
-      before do
-        create :match,
-          status: :quo,
-          diagnosed_need: answered_diagnosed_need,
-          updated_at: 6.days.ago
-
-        create :match,
-          status: :taking_care,
-          diagnosed_need: answered_diagnosed_need,
-          updated_at: 6.days.ago
-
-        create :match,
-          status: :done,
-          diagnosed_need: other_answered_diagnosed_need,
-          updated_at: 6.days.ago
-
-        create :match,
-          status: :not_for_me,
-          diagnosed_need: other_answered_diagnosed_need,
-          updated_at: 6.days.ago
-      end
-
-      it { is_expected.to match_array matches_with_no_one_in_charge }
-    end
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/services/expert_reminder_service_spec.rb
+++ b/spec/services/expert_reminder_service_spec.rb
@@ -10,12 +10,12 @@ describe ExpertReminderService do
 
     before do
       allow(Match).to receive(:needing_taking_care_update).and_return(match_needing_taking_care_update)
-      allow(Match).to receive(:with_no_one_in_charge).and_return(match_with_no_one_in_charge)
+      allow(DiagnosedNeed).to receive(:with_no_one_in_charge).and_return(match_with_no_one_in_charge)
     end
 
     context 'experts are different' do
       let(:match_needing_taking_care_update) { create_list :match, 2, :with_assistance_expert }
-      let(:match_with_no_one_in_charge) { create_list :match, 2, :with_assistance_expert }
+      let(:match_with_no_one_in_charge) { [create(:diagnosed_need, matches: create_list(:match, 2, :with_assistance_expert))] }
 
       it { expect { send_experts_reminders }.to change { Delayed::Job.count }.by(4) }
     end
@@ -28,7 +28,7 @@ describe ExpertReminderService do
         create_list :match, 2, :with_assistance_expert, assistance_expert: assistance_expert
       end
       let(:match_with_no_one_in_charge) do
-        create_list :match, 2, :with_assistance_expert, assistance_expert: assistance_expert
+        [create(:diagnosed_need, matches: create_list(:match, 2, :with_assistance_expert, assistance_expert: assistance_expert))]
       end
 
       it { expect { send_experts_reminders }.to change { Delayed::Job.count }.by(1) }


### PR DESCRIPTION
It’s a scope on DiagnosedNeed, not on Match. Additionally, the old implementation on match broke severely when using `ordered_by_status`.