### PR TITLE
Remove active_storage

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -2,7 +2,18 @@
 
 require_relative 'boot'
 
-require 'rails/all'
+require "rails"
+# Pick the frameworks you want:
+require "active_model/railtie"
+require "active_job/railtie"
+require "active_record/railtie"
+# require "active_storage/engine"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "action_view/railtie"
+require "action_cable/engine"
+require "sprockets/railtie"
+require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
It was introduced in Rails 5.2, but we don’t plan to use it.

(This is what our application.rb would look like if generated anew with `--skip-active-storage`.)