### PR TITLE
Better MailerPreviews

### DIFF
--- a/spec/mailers/previews/devise_mailer_preview.rb
+++ b/spec/mailers/previews/devise_mailer_preview.rb
@@ -10,6 +10,6 @@ class DeviseMailerPreview < ActionMailer::Preview
   private
 
   def user
-    FactoryBot.build(:user)
+    User.all.sample
   end
 end

--- a/spec/mailers/previews/devise_mailer_preview.rb
+++ b/spec/mailers/previews/devise_mailer_preview.rb
@@ -1,4 +1,4 @@
-class Devise::MailerPreview < ActionMailer::Preview
+class DeviseMailerPreview < ActionMailer::Preview
   def confirmation_instructions
     Devise::Mailer.confirmation_instructions(user, 'faketoken')
   end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -12,13 +12,13 @@ class UserMailerPreview < ActionMailer::Preview
   end
 
   def match_feedback
-    UserMailer.match_feedback(Feedback.last)
+    UserMailer.match_feedback(Feedback.all.sample)
   end
 
   private
 
   def user
-    FactoryBot.build(:user)
+    User.all.sample
   end
 
   def change_hash


### PR DESCRIPTION
* Fix a live-reload issue MailerPreviews.
* Don’t use factories in previews, to avoid polluting the dev DB.