### PR TITLE
Use simple_format() to display user-provided text

### DIFF
--- a/app/views/diagnoses/step5.html.haml
+++ b/app/views/diagnoses/step5.html.haml
@@ -44,7 +44,7 @@
               .ui.form
                 .field
                   %label= t('.diagnosed_needs_content_label')
-                  = diagnosed_need.content
+                  = simple_format(diagnosed_need.content)
         - if diagnosed_need.matches.empty?
           %tr.small.text.ui.tiny.table{ colspan: 2 }
             %td= t('.zero_contacted_expert')

--- a/app/views/mailers/user_mailer/match_feedback.html.haml
+++ b/app/views/mailers/user_mailer/match_feedback.html.haml
@@ -6,7 +6,7 @@
   company: @facility.company.name)
 
 %blockquote
-  %p= @feedback.description
+  %p= simple_format(@feedback.description)
 
 %p= t('.thankyou')
 %p= t('.summary_html', summary_link: link_to(t('.summary_link'), besoin_url(@diagnosed_need.diagnosis)))

--- a/app/views/needs/_expert_feedback.html.haml
+++ b/app/views/needs/_expert_feedback.html.haml
@@ -3,7 +3,7 @@
     .ui.top.attached.label
       %i.calendar.icon
       = I18n.l(feedback.created_at, format: :short)
-    %p.small.text= feedback.description
+    %p.small.text= simple_format(feedback.description)
     - if can_delete
       %a.ui.bottom.right.attached.label{ href: feedback_path(feedback,
        params.permit(:access_token)),

--- a/app/views/needs/show.html.haml
+++ b/app/views/needs/show.html.haml
@@ -43,7 +43,7 @@
               .ui.form
                 .field
                   %label= t('.diagnosed_needs_content_label')
-                  = diagnosed_need.content
+                  = simple_format(diagnosed_need.content)
 
         - diagnosed_need.matches.each do |match|
           - locals = { match: match }
@@ -71,7 +71,7 @@
               .ui.form
                 .field
                   %label= t('.diagnosed_needs_content_label')
-                  = diagnosed_need.content
+                  = simple_format(diagnosed_need.content)
         - if diagnosed_need.matches.empty?
           %tr.small.text.ui.tiny.table{ colspan: 2 }
             %td= t('.zero_contacted_expert')


### PR DESCRIPTION
This respects newlines in user-submitted comments.
