### PR TITLE
Tweak the order of relays in the contact page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -11,7 +11,7 @@ class HomeController < ApplicationController
   def cgu; end
 
   def contact
-    @relays = User.contact_relays.includes(relays: :territory)
+    @relays = User.contact_relays
     @product_team = User.with_contact_page_order
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,10 +30,11 @@ class User < ApplicationRecord
 
   scope :with_contact_page_order, (-> { where.not(contact_page_order: nil).order(:contact_page_order) })
   scope :contact_relays, (lambda do
-    where(contact_page_order: nil)
-        .joins(:relays)
-        .distinct
-        .order(:full_name)
+    not_admin
+      .joins(:relays)
+      .includes(relays: :territory)
+      .order('territories.name', :contact_page_order, :full_name)
+      .distinct
   end)
   scope :not_admin, (-> { where(is_admin: false) })
   scope :ordered_by_names, (-> { order(:full_name) })

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -58,13 +58,13 @@ RSpec.describe User, type: :model do
       end
     end
 
-    describe 'administrator_of_territory' do
+    describe 'contact_relays' do
       it do
-        user1 = create :user, full_name: 'bb'
-        create :relay, user: user1
-        user2 = create :user, full_name: 'aa'
-        create :relay, user: user2
-        user3 = create :user, contact_page_order: 2
+        user1 = create :user
+        create(:relay, user: user1, territory: create(:territory, name: 'bb'))
+        user2 = create :user
+        create(:relay, user: user2, territory: create(:territory, name: 'aa'))
+        user3 = create :user, is_admin: true
         create :relay, user: user3
 
         expect(User.contact_relays).to eq [user2, user1]


### PR DESCRIPTION
Sort them by territory name, then by “contact_page_order”.