### PR TITLE
Notify admins of abandoned needs

### DIFF
--- a/app/admin/diagnosed_need.rb
+++ b/app/admin/diagnosed_need.rb
@@ -6,9 +6,10 @@ ActiveAdmin.register DiagnosedNeed do
   includes :diagnosis, :question, :matches
 
   scope :all, default: true
-  scope :with_no_one_in_charge
-  scope :being_taken_care_of
-  scope :done
+  scopes = [:unsent, :with_no_one_in_charge, :abandoned, :being_taken_care_of, :done]
+  scopes.each do |s|
+    scope I18n.t("active_admin.diagnosed_needs.scopes.#{s}"), s
+  end
 
   ## index
   #
@@ -28,7 +29,9 @@ ActiveAdmin.register DiagnosedNeed do
     column :created_at
     column :updated_at
     column :content
-    column :status_synthesis
+    column :status_synthesis do |n|
+      t("activerecord.attributes.match.statuses_short.#{n.status_synthesis}")
+    end
     column t('activerecord.models.match.other'), :matches_count
 
     actions

--- a/app/models/diagnosed_need.rb
+++ b/app/models/diagnosed_need.rb
@@ -17,10 +17,14 @@ class DiagnosedNeed < ApplicationRecord
   scope :of_diagnosis, (-> (diagnosis) { where(diagnosis: diagnosis) })
   scope :of_question, (-> (question) { where(question: question) })
   scope :of_relay_or_expert, (-> (relay_or_expert) { joins(:matches).merge(Match.of_relay_or_expert(relay_or_expert)) })
-  scope :with_at_least_one_expert_done, -> { joins(:matches).where(matches: { status: :done }).distinct }
-  scope :with_no_one_in_charge, -> { where.not(matches: Match.where(status: [:done, :taking_care])) }
-  scope :done, -> { where(matches: Match.where(status: [:done])) }
+  scope :with_at_least_one_expert_done, -> { done }
+
+  scope :unsent, -> { left_outer_joins(:matches).where('matches.id IS NULL').distinct }
+  scope :with_no_one_in_charge, -> { joins(:matches).where.not(matches: Match.where(status: [:done, :taking_care])).distinct }
+  scope :abandoned, -> { joins(:matches).where.not(matches: Match.where(status: [:quo, :done, :taking_care])).distinct }
   scope :being_taken_care_of, -> { where(matches: Match.where(status: [:taking_care])).where.not(id: done) }
+  scope :done, -> { where(matches: Match.where(status: [:done])) }
+
   scope :made_in, (lambda do |date_range|
     joins(diagnosis: :visit)
       .where(diagnoses: { visits: { happened_on: date_range } })

--- a/app/services/admin_mailers_service.rb
+++ b/app/services/admin_mailers_service.rb
@@ -15,6 +15,7 @@ class AdminMailersService
       created_diagnoses_statistics
       updated_diagnoses_statistics
       completed_diagnoses_statistics
+      abandoned_needs_statistics
       matches_count_statistics
 
       AdminMailer.delay.weekly_statistics(@information_hash)
@@ -48,6 +49,11 @@ class AdminMailersService
       @information_hash[:completed_diagnoses] = {}
       @information_hash[:completed_diagnoses][:count] = @completed_diagnoses.count
       @information_hash[:completed_diagnoses][:items] = @completed_diagnoses
+    end
+
+    def abandoned_needs_statistics
+      abandoned_needs = DiagnosedNeed.abandoned
+      @information_hash[:abandoned_needs_count] = abandoned_needs.count
     end
 
     def matches_count_statistics

--- a/app/views/mailers/admin_mailer/weekly_statistics.html.haml
+++ b/app/views/mailers/admin_mailer/weekly_statistics.html.haml
@@ -42,6 +42,10 @@
       %li= link_to description, admin_diagnosis_url(diagnosis)
 
 %p
+  %a{ href: admin_diagnosed_needs_url(scope: 'en_souffrance') }
+    %strong= t('.abandoned_needs_count', count: @information_hash[:abandoned_needs_count])
+
+%p
   %strong= t('.matches_count', count: @information_hash[:matches_count])
 
 %p= t('.see_you_next_week')

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -4,6 +4,13 @@ fr:
     dashboard: Tableau de bord
     dashboard_welcome:
       invite_users: Inviter des utilisateurs
+    diagnosed_needs:
+      scopes:
+        abandoned: En souffrance
+        being_taken_care_of: En cours
+        done: Résolu
+        unsent: Non envoyé
+        with_no_one_in_charge: En attente
     experts:
       access: Accès
     institutions:

--- a/config/locales/active_record.fr.yml
+++ b/config/locales/active_record.fr.yml
@@ -24,6 +24,7 @@ fr:
         diagnosis: Analyse parente
         question: Besoin
         question_label: Nom du besoin
+        status_synthesis: Résumé
       diagnosis:
         archived_at: Date d’archivage
         content: Description
@@ -67,6 +68,11 @@ fr:
           not_for_me: Hors champ de compétence
           quo: En attente de prise en charge
           taking_care: En cours de prise en charge
+        statuses_short:
+          done: Résolu
+          not_for_me: En souffrance
+          quo: En attente
+          taking_care: En cours
         taken_care_of_at: Date de prise en charge
       question:
         category: Catégorie

--- a/config/locales/views/mailers/admin_mailer.fr.yml
+++ b/config/locales/views/mailers/admin_mailer.fr.yml
@@ -16,6 +16,10 @@ fr:
         user_has_signed_up: "%{full_name} <%{email}> vient de s’inscrire."
         view_their_account_html: "%{click_here_link} pour consulter son compte."
       weekly_statistics:
+        abandoned_needs_count:
+          one: Un besoin en souffrance
+          other: "%{count} besoins en souffrance"
+          zero: Aucun besoin en souffrance
         completed_diagnoses_count:
           one: 'Une analyse terminée :'
           other: "%{count} analyses terminées :"

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -38,6 +38,7 @@ describe AdminMailer do
         created_diagnoses: { count: 2, items: diagnoses },
         updated_diagnoses: { count: 2, items: diagnoses },
         completed_diagnoses: { count: 2, items: diagnoses },
+        abandoned_needs_count: 2,
         matches_count: 3
       }
     end

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -1,0 +1,41 @@
+class AdminMailerPreview < ActionMailer::Preview
+  def weekly_statistics
+    associations = [visit: [:advisor, facility: [:company]]]
+    @not_admin_diagnoses = Diagnosis.includes(associations).only_active.of_user(User.not_admin).reverse_chronological
+    @completed_diagnoses = @not_admin_diagnoses.completed.updated_last_week
+    created_diagnoses = @not_admin_diagnoses.in_progress.created_last_week
+
+    recently_signed_up_users = User.created_last_week
+    updated_diagnoses = @not_admin_diagnoses.in_progress.updated_last_week
+    updated_diagnoses = updated_diagnoses.where('diagnoses.created_at < ?', 1.week.ago)
+
+    abandoned_needs = DiagnosedNeed.abandoned
+    hash = {
+      signed_up_users: {
+        count: recently_signed_up_users.count,
+        items: recently_signed_up_users
+      },
+      created_diagnoses: {
+        count: created_diagnoses.count,
+        items: created_diagnoses
+      },
+      updated_diagnoses: {
+        count: updated_diagnoses.count,
+        items: updated_diagnoses
+      },
+      completed_diagnoses: {
+        count: @completed_diagnoses.count,
+        items: @completed_diagnoses
+      },
+      abandoned_needs_count: abandoned_needs.count,
+      matches_count: 12
+    }
+    AdminMailer.weekly_statistics(hash)
+  end
+
+  private
+
+  def match_with_person
+    Match.where.not(relay: nil).or(Match.where.not(assistance_expert: nil)).sample
+  end
+end

--- a/spec/services/admin_mailers_service_spec.rb
+++ b/spec/services/admin_mailers_service_spec.rb
@@ -23,6 +23,7 @@ describe AdminMailersService do
             created_diagnoses: { count: 0, items: [] },
             updated_diagnoses: { count: 0, items: [] },
             completed_diagnoses: { count: 0, items: [] },
+            abandoned_needs_count: 0,
             matches_count: 0
           }
         end
@@ -50,6 +51,7 @@ describe AdminMailersService do
             created_diagnoses: { count: 1, items: created_diagnoses },
             updated_diagnoses: { count: 1, items: updated_diagnoses },
             completed_diagnoses: { count: 2, items: completed_diagnoses.reverse },
+            abandoned_needs_count: 0,
             matches_count: 3
           }
         end


### PR DESCRIPTION
* Improved diagnosed needs scopes in /admin
* Add a section “X abandoned needs" in the weekly email