### PR TITLE
Avoid N+1 queries in admin

### DIFF
--- a/app/admin/feedback.rb
+++ b/app/admin/feedback.rb
@@ -1,7 +1,7 @@
 ActiveAdmin.register Feedback do
   menu parent: :diagnoses, priority: 4
+  permit_params :description
+  includes :match
 
   actions :index, :show, :update, :destroy
-
-  permit_params :description
 end

--- a/app/admin/match.rb
+++ b/app/admin/match.rb
@@ -4,8 +4,9 @@ ActiveAdmin.register Match do
   menu parent: :diagnoses, priority: 2
   permit_params :diagnosed_need_id, :assistances_experts_id, :relay_id, :status
   includes diagnosed_need: [diagnosis: [visit: [:advisor, facility: :company]]]
-  includes assistance_expert: :expert
+  includes :expert
   includes :relay
+  includes relay: :user
 
   index do
     selectable_column

--- a/db/migrate/20181019094404_add_index_to_experts.rb
+++ b/db/migrate/20181019094404_add_index_to_experts.rb
@@ -1,0 +1,5 @@
+class AddIndexToExperts < ActiveRecord::Migration[5.2]
+  def change
+    add_index :experts, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_25_131649) do
+ActiveRecord::Schema.define(version: 2018_10_19_094404) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -138,6 +138,7 @@ ActiveRecord::Schema.define(version: 2018_09_25_131649) do
     t.string "access_token"
     t.string "full_name"
     t.index ["access_token"], name: "index_experts_on_access_token"
+    t.index ["email"], name: "index_experts_on_email"
     t.index ["institution_id"], name: "index_experts_on_institution_id"
   end
 


### PR DESCRIPTION
`includes:` all the things.

I was actually expecting to see more of these. There’s another one on the User page when we tentatively match the experts with the same email; as this is not a proper ActiveRecord association, there’s no simple way to eager-load it. This isn’t a performance issue yet; we’ll discuss again when it becomes a problem.