### PR TITLE
Split the migration in two to workaround issues on staging

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -8,7 +8,7 @@ class Facility < ApplicationRecord
   has_many :visits
   has_many :diagnoses, through: :visits
 
-  validates :company, :commune, presence: true
+  validates :company, presence: true
   validates :siret, uniqueness: { allow_nil: true }
 
   scope :in_territory, (-> (territory) { where(commune: territory.communes) })

--- a/app/models/territory_city.rb
+++ b/app/models/territory_city.rb
@@ -3,7 +3,4 @@
 class TerritoryCity < ApplicationRecord
   belongs_to :territory
   belongs_to :commune
-
-  validates :territory, presence: true
-  validates :commune, presence: true
 end

--- a/db/migrate/20181023155512_populate_communes.rb
+++ b/db/migrate/20181023155512_populate_communes.rb
@@ -1,21 +1,11 @@
 class PopulateCommunes < ActiveRecord::Migration[5.2]
   def up
     Facility.find_each { |facility| facility.update(commune: Commune.find_or_create_by(insee_code: facility.city_code)) }
-    change_column_null :facilities, :commune_id, false
-
     TerritoryCity.find_each { |tc| tc.update(commune: Commune.find_or_create_by(insee_code: tc.city_code)) }
-    change_column_null :territory_cities, :commune_id, false
-
-    change_column_null :territory_cities, :territory_id, false
   end
 
   def down
-    change_column_null :territory_cities, :territory_id, true
-
-    change_column_null :territory_cities, :commune_id, true
     TerritoryCity.find_each { |tc| tc.update(commune: nil) }
-
-    change_column_null :facilities, :commune_id, true
     Facility.find_each { |facility| facility.update(commune: nil) }
 
     Commune.destroy_all

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -174,7 +174,7 @@ ActiveRecord::Schema.define(version: 2018_10_23_155512) do
     t.datetime "updated_at", null: false
     t.string "naf_code"
     t.string "readable_locality"
-    t.bigint "commune_id", null: false
+    t.bigint "commune_id"
     t.index ["commune_id"], name: "index_facilities_on_commune_id"
     t.index ["company_id"], name: "index_facilities_on_company_id"
   end
@@ -256,10 +256,10 @@ ActiveRecord::Schema.define(version: 2018_10_23_155512) do
 
   create_table "territory_cities", force: :cascade do |t|
     t.string "city_code"
-    t.bigint "territory_id", null: false
+    t.bigint "territory_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "commune_id", null: false
+    t.bigint "commune_id"
     t.index ["commune_id"], name: "index_territory_cities_on_commune_id"
     t.index ["territory_id"], name: "index_territory_cities_on_territory_id"
   end

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Facility, type: :model do
       is_expected.to belong_to :company
       is_expected.to validate_presence_of :company
       is_expected.to validate_uniqueness_of(:siret).ignoring_case_sensitivity
-      is_expected.to validate_presence_of :commune
     end
   end
 


### PR DESCRIPTION
I’m not sure why, but the PopulateColumns migration (#250) fails when adding the nonnull constraints, while all the data seems to be properly set.

I’ll just workaround it and do it in a distinct migration for now.