### PR TITLE
Don’t truncate or alter company names

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -18,8 +18,4 @@ class Company < ApplicationRecord
   def to_s
     name
   end
-
-  def name_short
-    name.first(40)
-  end
 end

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -14,6 +14,6 @@ class Facility < ApplicationRecord
   scope :in_territory, (-> (territory) { where(commune: territory.communes) })
 
   def to_s
-    "#{company.name_short} (#{readable_locality || commune.insee_code})"
+    "#{company.name} (#{readable_locality || commune.insee_code})"
   end
 end

--- a/app/models/use_cases/search_facility.rb
+++ b/app/models/use_cases/search_facility.rb
@@ -21,7 +21,7 @@ module UseCases
         siren = api_entreprise_company.entreprise['siren']
         legal_form_code = api_entreprise_company.entreprise['forme_juridique_code']
         company = Company.find_or_initialize_by siren: siren
-        company.update! name: company_name.titleize, legal_form_code: legal_form_code
+        company.update! name: company_name, legal_form_code: legal_form_code
         company
       end
 

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -21,7 +21,7 @@ class Visit < ApplicationRecord
   end
 
   def company_name
-    facility.company.name_short
+    facility.company.name
   end
 
   def company_description

--- a/app/services/user_daily_change_update_mailer_service.rb
+++ b/app/services/user_daily_change_update_mailer_service.rb
@@ -41,8 +41,7 @@ class UserDailyChangeUpdateMailerService
       change_hash[:expert_institution] = match.expert_institution_name
       change_hash[:question_title] = match.diagnosed_need.question_label
       change_hash[:company_name] = match.diagnosed_need
-        .diagnosis.visit
-        .facility.company.name_short
+        .diagnosis.visit.company_name
       change_hash[:start_date] = match.created_at.to_date
       change_hash
     end

--- a/app/views/diagnoses/index.html.haml
+++ b/app/views/diagnoses/index.html.haml
@@ -22,7 +22,7 @@
     %table.ui.table
       %tbody
         - diagnoses_in_progress.each do |diagnosis|
-          - company_name = diagnosis.visit.facility.company.name_short
+          - company_name = diagnosis.visit.company_name
           %tr
             %td
               %h3.ui.header= company_name
@@ -44,7 +44,7 @@
     %table.ui.table
       %tbody
         - diagnoses_completed.each do |diagnosis|
-          - company_name = diagnosis.visit.facility.company.name_short
+          - company_name = diagnosis.visit.company_name
           %tr
             %td
               %h3.ui.header

--- a/app/views/diagnoses/step2.html.haml
+++ b/app/views/diagnoses/step2.html.haml
@@ -14,7 +14,7 @@
       = diagnosis_form.text_area :content, placeholder: t('.diagnosis_content_placeholder'), rows: 2
 
     %p.small.text.justified
-      = t('.identify_needs', company_name: @diagnosis.visit.facility.company.name)
+      = t('.identify_needs', company_name: @diagnosis.visit.company_name)
 
     - @categories.each do |category|
       .ui.segments.shadow-less

--- a/app/views/diagnoses/step3.html.haml
+++ b/app/views/diagnoses/step3.html.haml
@@ -14,7 +14,7 @@
     = diagnosis_form.fields_for :visit do |visit_form|
       = visit_form.fields_for :visitee do |contact_form|
         %h3.ui.header
-          = t('.your_contact_in_the_company', company_name: visit.facility.company.name)
+          = t('.your_contact_in_the_company', company_name: visit.company_name)
 
         .field
           = contact_form.label t('.full_name')

--- a/app/views/diagnoses/step5.html.haml
+++ b/app/views/diagnoses/step5.html.haml
@@ -8,7 +8,7 @@
       %tr
         %td
           %h2.ui.header
-            = @diagnosis.visit.facility.company.name_short
+            = @diagnosis.visit.company_name
             .sub.header
               %i.calendar.icon
               .content= I18n.l(@diagnosis.visit.display_date, format: '%-d %B %Y')

--- a/app/views/needs/show.html.haml
+++ b/app/views/needs/show.html.haml
@@ -10,7 +10,7 @@
       %tr
         %td
           %h2.ui.header
-            = @diagnosis.visit.facility.company.name_short
+            = @diagnosis.visit.company_name
             .sub.header
               = I18n.l(@diagnosis.visit.display_date, format: '%-d %B %Y')
         %td.collapsing

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -14,12 +14,4 @@ RSpec.describe Company, type: :model do
       expect(company.to_s).to eq 'Octo'
     end
   end
-
-  describe 'name_short' do
-    it do
-      name = 'This name is very long and should be shorter if we want to display it'
-      company = create :company, name: name
-      expect(company.name_short.length).to be < name.length
-    end
-  end
 end

--- a/spec/services/user_daily_change_update_mailer_service_spec.rb
+++ b/spec/services/user_daily_change_update_mailer_service_spec.rb
@@ -22,7 +22,7 @@ describe UserDailyChangeUpdateMailerService do
             expert_name: match2.expert_full_name,
             expert_institution: match2.expert_institution_name,
             question_title: match2.diagnosed_need.question_label,
-            company_name: match2.diagnosed_need.diagnosis.visit.facility.company.name_short,
+            company_name: match2.diagnosed_need.diagnosis.visit.company_name,
             start_date: match2.created_at.to_date,
             old_status: 'quo',
             current_status: 'done'
@@ -59,7 +59,7 @@ describe UserDailyChangeUpdateMailerService do
             expert_name: match2.expert_full_name,
             expert_institution: match2.expert_institution_name,
             question_title: match2.diagnosed_need.question_label,
-            company_name: match2.diagnosed_need.diagnosis.visit.facility.company.name_short,
+            company_name: match2.diagnosed_need.diagnosis.visit.company_name,
             start_date: match2.created_at.to_date,
             old_status: 'quo',
             current_status: 'done'
@@ -68,7 +68,7 @@ describe UserDailyChangeUpdateMailerService do
             expert_name: match3.expert_full_name,
             expert_institution: match3.expert_institution_name,
             question_title: match2.diagnosed_need.question_label,
-            company_name: match2.diagnosed_need.diagnosis.visit.facility.company.name_short,
+            company_name: match2.diagnosed_need.diagnosis.visit.company_name,
             start_date: match3.created_at.to_date,
             old_status: 'quo',
             current_status: 'done'


### PR DESCRIPTION
* Never truncate company names: remove the `name_short` method and only use the full name; this is a UI issue, we’ll fix it in the UI if we encounter it again.
* Do not alter company names when importing: Don’t “titleize” when importing from the SIRENE api: we’ll titleize, if relevant, in the UI.