### PR TITLE
Add “Antenne” creation tooling

### DIFF
--- a/app/admin/antenne.rb
+++ b/app/admin/antenne.rb
@@ -50,10 +50,12 @@ ActiveAdmin.register Antenne do
     end
 
     render partial: 'admin/matches', locals: {
+      table_name: I18n.t('activerecord.attributes.match.sent', count: antenne.sent_matches.size),
       matches_relation: antenne.sent_matches
     }
 
     render partial: 'admin/matches', locals: {
+      table_name: I18n.t('activerecord.attributes.match.received', count: antenne.received_matches.size),
       matches_relation: antenne.received_matches
     }
   end

--- a/app/admin/antenne.rb
+++ b/app/admin/antenne.rb
@@ -1,0 +1,60 @@
+ActiveAdmin.register Antenne do
+  menu parent: :experts, priority: 3
+  includes :institution, :communes, :experts, :users
+
+  ## Index
+  #
+  index do
+    selectable_column
+    id_column
+    column :name
+    column :institution
+    column(:communes) { |a| a.communes.size }
+    column(:experts) { |a| a.experts.size }
+    column(:users) { |a| a.users.size }
+  end
+
+  filter :name
+  filter :institution
+  filter :institution_name
+
+  ## Show
+  #
+  show do
+    attributes_table do
+      row :name
+      row :created_at
+      row :updated_at
+      row(:communes) do |a|
+        safe_join(a.communes.map do |commune|
+          link_to commune, admin_commune_path(commune)
+        end, ', '.html_safe)
+      end
+    end
+
+    panel I18n.t('activerecord.models.expert.other') do
+      table_for antenne.experts do
+        column(:full_name) { |e| link_to(e, admin_expert_path(e)) }
+        column :email
+        column :phone_number
+        column(:assistances) { |e| e.assistances.size }
+      end
+    end
+
+    panel I18n.t('activerecord.models.user.other') do
+      table_for antenne.users do
+        column(:full_name) { |u| link_to(u, admin_user_path(u)) }
+        column :email
+        column :phone_number
+      end
+    end
+
+    render partial: 'admin/matches', locals: {
+      matches_relation: antenne.sent_matches
+    }
+
+    render partial: 'admin/matches', locals: {
+      matches_relation: antenne.received_matches
+    }
+  end
+end

--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -85,6 +85,10 @@ ActiveAdmin.register Expert do
     link_to t('active_admin.person.normalize_values'), normalize_values_admin_expert_path(expert)
   end
 
+  action_item :convert_to_antenne, only: :show do
+    link_to t('active_admin.antenne.create_antenne'), convert_to_antenne_admin_expert_path(resource)
+  end
+
   ## Form
   #
   form do |f|
@@ -129,6 +133,11 @@ ActiveAdmin.register Expert do
   member_action :normalize_values do
     resource.normalize_values!
     redirect_back fallback_location: collection_path, alert: t('active_admin.person.normalize_values_done')
+  end
+
+  member_action :convert_to_antenne do
+    antenne = Antenne.create_from_expert!(resource)
+    redirect_to admin_antenne_path(antenne)
   end
 
   batch_action I18n.t('active_admin.person.normalize_values') do |ids|

--- a/app/admin/institution.rb
+++ b/app/admin/institution.rb
@@ -4,6 +4,17 @@ ActiveAdmin.register Institution do
   menu parent: :experts, priority: 1
   permit_params :name
 
+  ## Index
+  #
+  filter :experts, collection: -> { Expert.ordered_by_names }
+  filter :name
+  filter :created_at
+  filter :updated_at
+  filter :qualified_for_commerce
+  filter :qualified_for_artisanry
+
+  ## Show
+  #
   show do
     attributes_table do
       row :name
@@ -19,10 +30,14 @@ ActiveAdmin.register Institution do
     end
   end
 
-  filter :experts, collection: -> { Expert.ordered_by_names }
-  filter :name
-  filter :created_at
-  filter :updated_at
-  filter :qualified_for_commerce
-  filter :qualified_for_artisanry
+  action_item :convert_to_antenne, only: :show do
+    link_to t('active_admin.antenne.create_antenne'), convert_to_antenne_admin_institution_path(resource)
+  end
+
+  ## Actions
+  #
+  member_action :convert_to_antenne do
+    antenne = Antenne.create_from_institution!(resource)
+    redirect_to admin_antenne_path(antenne)
+  end
 end

--- a/app/admin/territory.rb
+++ b/app/admin/territory.rb
@@ -5,6 +5,13 @@ ActiveAdmin.register Territory do
   permit_params :name,
     :insee_codes
 
+  ## index
+  #
+  filter :experts, collection: -> { Expert.ordered_by_names }
+  filter :name
+  filter :created_at
+  filter :updated_at
+
   ## Show
   #
   show do
@@ -36,6 +43,12 @@ ActiveAdmin.register Territory do
     end
   end
 
+  action_item :convert_to_antenne, only: :show do
+    link_to t('active_admin.antenne.create_antenne'), convert_to_antenne_admin_territory_path(resource)
+  end
+
+  # Form
+  #
   form do |f|
     f.inputs I18n.t('activerecord.attributes.territory.name') do
       f.input :name
@@ -48,8 +61,10 @@ ActiveAdmin.register Territory do
     f.actions
   end
 
-  filter :experts, collection: -> { Expert.ordered_by_names }
-  filter :name
-  filter :created_at
-  filter :updated_at
+  ## Actions
+  #
+  member_action :convert_to_antenne do
+    antenne = Antenne.create_from_territory!(resource)
+    redirect_to admin_antenne_path(antenne)
+  end
 end

--- a/app/models/antenne.rb
+++ b/app/models/antenne.rb
@@ -18,4 +18,59 @@ class Antenne < ApplicationRecord
   def received_matches
     Match.of_relay_or_expert(experts)
   end
+
+  ## Temporary: constructors from Institution, Territory, Expert
+  #
+  class << self
+    def default_institution
+      Institution.find_by(name: '!Institution temporaire')
+    end
+
+    def create_from_territory!(territory)
+      a = Antenne.create!(
+        name: territory.name,
+        institution: default_institution,
+        experts: territory.experts,
+        communes: territory.communes,
+        users: territory.experts.flat_map(&:users)
+      )
+
+      territory.update(name: '(antenne créée) ' + territory.name)
+
+      a
+    end
+
+    def create_from_institution!(institution)
+      # Make sure all experts have the same territories
+      if institution.experts.map(&:territories).uniq.length > 1
+        raise 'All experts from the institution must have the same territories'
+      end
+
+      a = Antenne.create!(
+        name: institution.name,
+        institution: institution,
+        experts: institution.experts,
+        communes: institution.experts.first.territories.flat_map(&:communes).uniq,
+        users: institution.experts.flat_map(&:users)
+      )
+
+      institution.update(name: '(antenne créée) ' + institution.name)
+
+      a
+    end
+
+    def create_from_expert!(expert)
+      a = Antenne.create!(
+        name: expert.full_name,
+        institution: expert.institution,
+        experts: [expert],
+        communes: expert.territories.flat_map(&:communes).uniq,
+        users: expert.users
+      )
+
+      expert.update(full_name: '(antenne créée) ' + expert.full_name)
+
+      a
+    end
+  end
 end

--- a/app/views/admin/_matches.html.arb
+++ b/app/views/admin/_matches.html.arb
@@ -1,4 +1,5 @@
-panel "#{I18n.t('activerecord.models.match.other')} (#{matches_relation.length})" do
+table_name = table_name || "#{I18n.t('activerecord.models.match', count: matches_relation.size)} (#{matches_relation.size})"
+panel table_name do
   table_for matches_relation
     .includes(diagnosed_need: [diagnosis: [visit: [facility: :company]]])
     .includes(diagnosed_need: [diagnosis: [visit: :advisor]])

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -1,6 +1,8 @@
 ---
 fr:
   active_admin:
+    antenne:
+      create_antenne: Convertir en Antenne
     dashboard: Tableau de bord
     dashboard_welcome:
       invite_users: Inviter des utilisateurs

--- a/config/locales/active_record.fr.yml
+++ b/config/locales/active_record.fr.yml
@@ -64,7 +64,13 @@ fr:
         expert_full_name: Référent contacté
         expert_institution_name: Institution du référent
         expert_viewed_page_at: Date de consultation par le référent
+        received:
+          one: Mise en relation reçue
+          other: Mises en relation reçues (%{count})
         relay: Référent (Relais local)
+        sent:
+          one: Mise en relation envoyée
+          other: Mises en relation envoyées (%{count})
         status: Statut
         statuses:
           done: Besoin résolu

--- a/config/locales/active_record.fr.yml
+++ b/config/locales/active_record.fr.yml
@@ -2,6 +2,8 @@
 fr:
   activerecord:
     attributes:
+      antenne:
+        name: Nom
       assistance:
         description: Description
         experts: Référents


### PR DESCRIPTION
In the admin pages, allow creating Antennes from existing Institutions/Territories/Experts.

This will be the central step for https://trello.com/c/z9Ty2rNK/270-nettoyage-institutions and https://trello.com/c/uzBpixmv/264-nettoyage-territoire. Once the data is converted, we’ll be able to switch to the new logic, and get rid of the old associations.