### PR TITLE
Add tooling and admin for Antennes

### DIFF
--- a/app/admin/antenne.rb
+++ b/app/admin/antenne.rb
@@ -2,6 +2,12 @@ ActiveAdmin.register Antenne do
   menu parent: :experts, priority: 3
   includes :institution, :communes, :experts, :users
 
+  permit_params [
+    :name,
+    :institution_id,
+    :insee_codes
+  ]
+
   ## Index
   #
   index do
@@ -33,20 +39,20 @@ ActiveAdmin.register Antenne do
       end
     end
 
+    panel I18n.t('activerecord.models.user.other') do
+      table_for antenne.users do
+        column(:full_name) { |u| link_to(u, admin_user_path(u)) }
+        column :email
+        column :phone_number
+      end
+    end
+
     panel I18n.t('activerecord.models.expert.other') do
       table_for antenne.experts do
         column(:full_name) { |e| link_to(e, admin_expert_path(e)) }
         column :email
         column :phone_number
         column(:assistances) { |e| e.assistances.size }
-      end
-    end
-
-    panel I18n.t('activerecord.models.user.other') do
-      table_for antenne.users do
-        column(:full_name) { |u| link_to(u, admin_user_path(u)) }
-        column :email
-        column :phone_number
       end
     end
 
@@ -59,5 +65,38 @@ ActiveAdmin.register Antenne do
       table_name: I18n.t('activerecord.attributes.match.received', count: antenne.received_matches.size),
       matches_relation: antenne.received_matches
     }
+  end
+
+  ## Form
+  #
+  form do |f|
+    f.inputs do
+      f.input :name
+      f.input :institution, as: :ajax_select, data: {
+        url: :admin_institutions_path,
+        search_fields: [:name],
+        limit: 999,
+      }
+
+      f.input :insee_codes
+    end
+
+    f.inputs do
+      f.input :users, label: t('activerecord.attributes.antenne.users'), as: :ajax_select, data: {
+        url: :admin_users_path,
+        search_fields: [:full_name],
+        limit: 999,
+      }
+    end
+
+    f.inputs do
+      f.input :experts, label: t('activerecord.attributes.antenne.experts'), as: :ajax_select, data: {
+        url: :admin_experts_path,
+        search_fields: [:full_name],
+        limit: 999,
+      }
+    end
+
+    f.actions
   end
 end

--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -8,6 +8,7 @@ ActiveAdmin.register Expert do
     :full_name,
     :role,
     :institution_id,
+    :antenne_id,
     :email,
     :phone_number,
     user_ids: [],
@@ -24,6 +25,7 @@ ActiveAdmin.register Expert do
     id_column
     column :full_name
     column :institution
+    column :antenne
     column(:users) { |expert| expert.users.size }
     column :role
     column :email
@@ -48,6 +50,7 @@ ActiveAdmin.register Expert do
     attributes_table do
       row :full_name
       row :institution
+      row :antenne
       row :role
       row :email
       row :phone_number
@@ -96,6 +99,11 @@ ActiveAdmin.register Expert do
       f.input :full_name
       f.input :institution, as: :ajax_select, data: {
         url: :admin_institutions_path,
+        search_fields: [:name],
+        limit: 999,
+      }
+      f.input :antenne, as: :ajax_select, data: {
+        url: :admin_antennes_path,
         search_fields: [:name],
         limit: 999,
       }

--- a/app/admin/institution.rb
+++ b/app/admin/institution.rb
@@ -2,7 +2,12 @@
 
 ActiveAdmin.register Institution do
   menu parent: :experts, priority: 1
-  permit_params :name
+  permit_params [
+    :name,
+    :qualified_for_commerce,
+    :qualified_for_artisanry,
+    antenne_ids: []
+  ]
 
   ## Index
   #
@@ -22,10 +27,9 @@ ActiveAdmin.register Institution do
       row :updated_at
     end
 
-    panel I18n.t('active_admin.institutions.experts') do
-      table_for institution.experts do
-        column I18n.t('activerecord.attributes.expert.full_name'), (proc { |expert| link_to(expert, admin_expert_path(expert)) })
-        column :email
+    panel I18n.t('activerecord.attributes.institution.antennes') do
+      table_for institution.antennes do
+        column(I18n.t('activerecord.attributes.antenne.name')) { |antenne| link_to(antenne, admin_antenne_path(antenne)) }
       end
     end
   end
@@ -34,10 +38,34 @@ ActiveAdmin.register Institution do
     link_to t('active_admin.antenne.create_antenne'), convert_to_antenne_admin_institution_path(resource)
   end
 
+  ## Form
+  #
+  form do |f|
+    f.inputs do
+      f.input :name
+      f.input :qualified_for_commerce
+      f.input :qualified_for_artisanry
+    end
+    f.inputs do
+      f.input :antennes, label: t('activerecord.attributes.institution.antennes'), as: :ajax_select, data: {
+        url: :admin_antennes_path,
+        search_fields: [:name],
+        limit: 999,
+      }
+    end
+
+    f.actions
+  end
+
   ## Actions
   #
   member_action :convert_to_antenne do
     antenne = Antenne.create_from_institution!(resource)
     redirect_to admin_antenne_path(antenne)
+  end
+
+  batch_action I18n.t('active_admin.antenne.create_antenne') do |ids|
+    batch_action_collection.find(ids).each { |institution| Antenne.create_from_institution!(institution) }
+    redirect_to admin_antennes_path, notice: I18n.t('active_admin.antenne.antennes_created')
   end
 end

--- a/app/admin/territory.rb
+++ b/app/admin/territory.rb
@@ -67,4 +67,9 @@ ActiveAdmin.register Territory do
     antenne = Antenne.create_from_territory!(resource)
     redirect_to admin_antenne_path(antenne)
   end
+
+  batch_action I18n.t('active_admin.antenne.create_antenne') do |ids|
+    batch_action_collection.find(ids).each { |territory| Antenne.create_from_territory!(territory) }
+    redirect_to admin_antennes_path, notice: I18n.t('active_admin.antenne.antennes_created')
+  end
 end

--- a/app/models/antenne.rb
+++ b/app/models/antenne.rb
@@ -19,6 +19,29 @@ class Antenne < ApplicationRecord
     Match.of_relay_or_expert(experts)
   end
 
+  ##
+  #
+  def to_s
+    name
+  end
+
+  def insee_codes
+    communes.pluck(:insee_code)
+  end
+
+  def insee_codes=(codes_raw)
+    wanted_codes = codes_raw.split(/[,\s]/).delete_if(&:empty?)
+    if wanted_codes.any? { |code| code !~ Commune::INSEE_CODE_FORMAT }
+      raise 'Invalid city codes'
+    end
+
+    wanted_codes.each do |code|
+      Commune.find_or_create_by(insee_code: code)
+    end
+
+    self.communes = Commune.where(insee_code: wanted_codes)
+  end
+
   ## Temporary: constructors from Institution, Territory, Expert
   #
   class << self

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -2,6 +2,7 @@
 fr:
   active_admin:
     antenne:
+      antennes_created: Antennes créées
       create_antenne: Convertir en Antenne
     dashboard: Tableau de bord
     dashboard_welcome:
@@ -15,8 +16,6 @@ fr:
         with_no_one_in_charge: En attente
     experts:
       access: Accès
-    institutions:
-      experts: Réferents
     matches:
       deleted: "%{expert} (supprimé)"
     person:

--- a/config/locales/active_record.fr.yml
+++ b/config/locales/active_record.fr.yml
@@ -3,7 +3,10 @@ fr:
   activerecord:
     attributes:
       antenne:
+        experts: Équipes / Référents
+        insee_codes: Zone d’intervention
         name: Nom
+        users: Conseillers
       assistance:
         description: Description
         experts: Référents
@@ -51,6 +54,7 @@ fr:
         description: Description
         match: Mise en relation
       institution:
+        antennes: Antennes
         email: E-mail
         name: Raison sociale
         phone_number: Numéro de téléphone


### PR DESCRIPTION
Missing from the previous iteration:
* batch convert actions in Institution, Territory and Expert
* form in Institution: mass-assign the Antennes
* form in Antenne: mass-assign Users and Experts