### PR TITLE
Bugfixes for admin/territory and admin/antenne

### DIFF
--- a/app/admin/antenne.rb
+++ b/app/admin/antenne.rb
@@ -5,7 +5,9 @@ ActiveAdmin.register Antenne do
   permit_params [
     :name,
     :institution_id,
-    :insee_codes
+    :insee_codes,
+    user_ids: [],
+    expert_ids: [],
   ]
 
   ## Index

--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -12,7 +12,6 @@ ActiveAdmin.register Expert do
     :email,
     :phone_number,
     user_ids: [],
-    territory_ids: [],
     assistance_ids: [],
     expert_territories_attributes: %i[id territory_id _create _update _destroy],
     assistances_experts_attributes: %i[id assistance_id _create _update _destroy]
@@ -36,7 +35,6 @@ ActiveAdmin.register Expert do
     end
   end
 
-  filter :territories, as: :ajax_select, data: { url: :admin_territories_path, search_fields: [:name] }
   filter :institution, as: :ajax_select, data: { url: :admin_institutions_path, search_fields: [:name] }
   filter :antenne, as: :ajax_select, data: { url: :admin_antennes_path, search_fields: [:name] }
   filter :assistances, as: :ajax_select, data: { url: :admin_assistances_path, search_fields: [:title, :description] }
@@ -55,12 +53,18 @@ ActiveAdmin.register Expert do
       row :role
       row :email
       row :phone_number
+      row :access_token
     end
     attributes_table do
-      row(:territories) do |expert|
+      row "Territoires (temporaire)" do |expert|
         safe_join(expert.territories.map do |territory|
           link_to territory.name, admin_territory_path(territory)
         end, ', '.html_safe)
+      end
+    end
+    panel I18n.t('activerecord.attributes.expert.users') do
+      table_for expert.users do
+        column { |user| link_to(user.full_name, admin_user_path(user)) + "<br/> #{user.role}, #{user.institution}".html_safe }
       end
     end
     panel I18n.t('activerecord.attributes.expert.assistances') do
@@ -71,18 +75,6 @@ ActiveAdmin.register Expert do
     end
 
     render partial: 'admin/matches', locals: { matches_relation: expert.matches }
-  end
-
-  sidebar I18n.t('activerecord.attributes.user.experts'), only: :show do
-    table_for expert.users do
-      column { |user| link_to(user.full_name, admin_user_path(user)) + "<br/> #{user.role}, #{user.institution}".html_safe }
-    end
-  end
-
-  sidebar I18n.t('active_admin.experts.access'), only: :show do
-    attributes_table do
-      row :access_token
-    end
   end
 
   action_item :normalize_values, only: :show do
@@ -108,14 +100,6 @@ ActiveAdmin.register Expert do
       f.input :users, label: t('activerecord.models.user.other'), as: :ajax_select, data: {
         url: :admin_users_path,
         search_fields: [:full_name],
-        limit: 999,
-      }
-    end
-
-    f.inputs t('activerecord.attributes.expert.territories') do
-      f.input :territories, as: :ajax_select, data: {
-        url: :admin_territories_path,
-        search_fields: [:name],
         limit: 999,
       }
     end

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -11,8 +11,6 @@ fr:
         done: Résolu
         unsent: Non envoyé
         with_no_one_in_charge: En attente
-    experts:
-      access: Accès
     matches:
       deleted: "%{expert} (supprimé)"
     person:


### PR DESCRIPTION
Allow modifying the team (Experts + Users) of an Antenne, and prevent modifying the (deprecated) Territories of an Expert.