### PR TITLE
Improve intervention zones display in Admin

### DIFF
--- a/app/admin/antenne.rb
+++ b/app/admin/antenne.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Antenne do
-  menu parent: :experts, priority: 2
+  menu parent: :experts, priority: 1
   includes :institution, :communes, :experts, :users
 
   permit_params [

--- a/app/admin/antenne.rb
+++ b/app/admin/antenne.rb
@@ -38,7 +38,7 @@ ActiveAdmin.register Antenne do
     attributes_table do
       row :name
       row :institution
-      row(:communes) { |a| safe_join(a.communes.map { |commune| link_to commune, admin_commune_path(commune) }, ', '.html_safe) }
+      row(:communes) { |a| intervention_zone_description(a) }
     end
 
     render partial: 'admin/users', locals: {

--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -55,8 +55,8 @@ ActiveAdmin.register Expert do
       row :full_name
       row :institution
       row :antenne
-      row(:communes) { |e| safe_join(e.communes.map { |commune| link_to commune, admin_commune_path(commune) }, ', '.html_safe) }
       row :custom_communes?
+      row(:communes) { |expert| intervention_zone_description(expert) }
       row :role
       row :email
       row :phone_number

--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -27,7 +27,7 @@ ActiveAdmin.register Expert do
   filter :role
 
   scope :all, default: true
-  scope I18n.t("active_admin.experts.scopes.with_custom_zone"), :with_custom_zone
+  scope I18n.t("active_admin.experts.scopes.with_custom_communes"), :with_custom_communes
 
   config.sort_order = 'full_name_asc'
 
@@ -37,7 +37,8 @@ ActiveAdmin.register Expert do
     column :full_name
     column :institution
     column :antenne
-    column :custom_zone?
+    column :custom_communes?
+    column(:communes) { |expert| expert.communes.size }
     column(:users) { |expert| expert.users.size }
     column :role
     column :email
@@ -54,8 +55,8 @@ ActiveAdmin.register Expert do
       row :full_name
       row :institution
       row :antenne
-      row :custom_zone?
       row(:communes) { |e| safe_join(e.communes.map { |commune| link_to commune, admin_commune_path(commune) }, ', '.html_safe) }
+      row :custom_communes?
       row :role
       row :email
       row :phone_number

--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -2,7 +2,7 @@
 
 ActiveAdmin.register Expert do
   menu priority: 6
-  includes :institution, :assistances, :users
+  includes :antenne, :institution, :communes, :assistances, :users
 
   permit_params [
     :full_name,

--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -20,7 +20,7 @@ ActiveAdmin.register Expert do
   #
   filter :institution, as: :ajax_select, data: { url: :admin_institutions_path, search_fields: [:name] }
   filter :antenne, as: :ajax_select, data: { url: :admin_antennes_path, search_fields: [:name] }
-  filter :assistances, as: :ajax_select, data: { url: :admin_assistances_path, search_fields: [:title, :description] }
+  filter :assistances, as: :ajax_select, data: { url: :admin_assistances_path, search_fields: [:title] }
   filter :full_name
   filter :email
   filter :phone_number

--- a/app/admin/institution.rb
+++ b/app/admin/institution.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register Institution do
-  menu parent: :experts, priority: 1
+  menu parent: :experts, priority: 2
   permit_params [
     :name,
     :qualified_for_commerce,

--- a/app/admin/institution.rb
+++ b/app/admin/institution.rb
@@ -9,7 +9,7 @@ ActiveAdmin.register Institution do
     antenne_ids: []
   ]
 
-  includes :antennes, :experts
+  includes :antennes, :users, :experts
 
   ## Index
   #

--- a/app/admin/territory.rb
+++ b/app/admin/territory.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register Territory do
   menu priority: 8
   permit_params :name, :insee_codes
 
-  includes :users, :advisors, :experts
+  includes :communes
 
   ## index
   #

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,0 +1,15 @@
+module AdminHelper
+  def intervention_zone_description(many_communes)
+    summary = many_communes.intervention_zone_summary
+    descriptions = summary[:territories].map do |hash|
+      territory = hash[:territory]
+      link = link_to(territory, admin_antenne_path(territory))
+      "#{link} : #{hash[:included]} / #{territory.communes.count}".html_safe
+    end
+    other = summary[:other]
+    if other > 0
+      descriptions << "#{I18n.t('other')} : #{other}"
+    end
+    descriptions.join("<br/>").html_safe
+  end
+end

--- a/app/models/commune.rb
+++ b/app/models/commune.rb
@@ -19,7 +19,7 @@ class Commune < ApplicationRecord
   def all_experts
     # Direct or through Antennes; returns an ActiveRecord Relation rather than an array.
     Expert.where(id: direct_experts)
-      .or(Expert.where(id: antenne_experts).where(id: Expert.without_custom_zone)) # Experts of the antennes on this Commune, who don’t override their Antenne zone.
+      .or(Expert.where(id: antenne_experts).where(id: Expert.without_custom_communes)) # Experts of the antennes on this Commune, who don’t override their Antenne zone.
   end
 
   ##

--- a/app/models/concerns/many_communes.rb
+++ b/app/models/concerns/many_communes.rb
@@ -4,6 +4,7 @@ module ManyCommunes
     ## Relations and Validations
     #
     has_and_belongs_to_many :communes
+    has_many :territories, through: :communes
 
     ## Insee Codes acccessors
     #
@@ -22,6 +23,30 @@ module ManyCommunes
       end
 
       self.communes = Commune.where(insee_code: wanted_codes)
+    end
+
+    ## Territories description
+    #
+    def intervention_zone_summary
+      self_communes = communes.pluck(:id)
+      territories_covered = []
+      remaining_communes = self_communes.clone
+      self.territories.bassins_emploi.distinct.includes(:communes).ordered_by_name.each do |territory|
+        territory_communes = territory.communes.pluck(:id)
+        territory_communes_in_self = territory_communes & self_communes
+        if territory_communes_in_self.size > 0
+          territories_covered << {
+            territory: territory,
+            included: territory_communes_in_self.count,
+          }
+          remaining_communes -= territory_communes
+        end
+      end
+
+      {
+        territories: territories_covered,
+        other: remaining_communes.count
+      }
     end
   end
 end

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -37,8 +37,8 @@ class Expert < ApplicationRecord
       .order('institutions.name', 'antennes.name', :full_name)
   end
 
-  scope :with_custom_zone, -> { joins(:communes).distinct }
-  scope :without_custom_zone, -> { left_outer_joins(:communes).where(communes: { id: nil }) }
+  scope :with_custom_communes, -> { joins(:communes).distinct }
+  scope :without_custom_communes, -> { left_outer_joins(:communes).where(communes: { id: nil }) }
 
   ##
   #
@@ -56,7 +56,7 @@ class Expert < ApplicationRecord
     self.users.size == 1 && self.users.first.experts == [self]
   end
 
-  def custom_zone?
+  def custom_communes?
     communes.any?
   end
 

--- a/app/views/admin/_experts.html.arb
+++ b/app/views/admin/_experts.html.arb
@@ -6,9 +6,9 @@ end
 
 panel table_name do
   table_for experts do
-    column(:full_name) { |expert| link_to(expert, admin_expert_path(expert)) }
-    column :antenne
     column :institution
+    column :antenne
+    column(:full_name) { |expert| link_to(expert, admin_expert_path(expert)) }
     column :email
     column :phone_number
     column(:assistances) { |expert| expert.assistances.size }

--- a/app/views/admin/_users.html.arb
+++ b/app/views/admin/_users.html.arb
@@ -6,9 +6,9 @@ end
 
 panel table_name do
   table_for users do
-    column(:full_name) { |user| link_to(user, admin_user_path(user)) }
-    column :antenne
     column :institution
+    column :antenne
+    column(:full_name) { |user| link_to(user, admin_user_path(user)) }
     column :email
     column :phone_number
   end

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -13,7 +13,7 @@ fr:
         with_no_one_in_charge: En attente
     experts:
       scopes:
-        with_custom_zone: Zone spécifique
+        with_custom_communes: Zone spécifique
     matches:
       deleted: "%{expert} (supprimé)"
     person:

--- a/config/locales/active_record.fr.yml
+++ b/config/locales/active_record.fr.yml
@@ -42,7 +42,8 @@ fr:
         access_token: Token d’accès
         antenne: Antenne
         assistances: Champs de compétence
-        custom_zone?: Zone spécifique ?
+        communes: Zone d’intervention
+        custom_communes?: Zone spécifique ?
         email: E-mail
         full_name: Prénom et Nom
         institution: Institution

--- a/config/locales/common.fr.yml
+++ b/config/locales/common.fr.yml
@@ -7,6 +7,7 @@ fr:
   edit: Modifier
   next_step: Passer à la suite
   'no': non
+  other: Autre
   previous_step: Précédent
   search: Rechercher
   sign_in: Connexion

--- a/spec/models/concerns/many_communes_spec.rb
+++ b/spec/models/concerns/many_communes_spec.rb
@@ -61,4 +61,31 @@ RSpec.describe ManyCommunes do
       end
     end
   end
+
+  describe 'intervention_zone_summary' do
+    subject { antenne.intervention_zone_summary }
+
+    let(:antenne) { create :antenne, communes: communes1 + communes2 + communes3 }
+    let(:communes1) { create_list(:commune, 4) }
+    let(:communes2) { create_list(:commune, 4) }
+    let(:communes3) { create_list(:commune, 4) }
+    let!(:territory1) { create :territory, name: "A", bassin_emploi: true, communes: communes1 }
+    let!(:territory2) { create :territory, name: "B", bassin_emploi: true, communes: communes2.take(2) }
+
+    it do
+      is_expected.to eq({
+        territories: [
+          {
+            territory: territory1,
+            included: 4,
+          },
+          {
+            territory: territory2,
+            included: 2,
+          }
+        ],
+        other: 6
+      })
+    end
+  end
 end

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -87,22 +87,22 @@ RSpec.describe Expert, type: :model do
     end
 
     describe 'commune zone scopes' do
-      let(:expert_with_custom_zone) { create :expert, antenne: antenne, communes: [commune1] }
-      let(:expert_without_custom_zone) { create :expert, antenne: antenne }
+      let(:expert_with_custom_communes) { create :expert, antenne: antenne, communes: [commune1] }
+      let(:expert_without_custom_communes) { create :expert, antenne: antenne }
       let(:commune1) { create :commune }
       let(:commune2) { create :commune }
       let!(:antenne) { create :antenne, communes: [commune1, commune2] }
 
-      describe 'with_custom_zone' do
-        subject { Expert.with_custom_zone }
+      describe 'with_custom_communes' do
+        subject { Expert.with_custom_communes }
 
-        it { is_expected.to match_array [expert_with_custom_zone] }
+        it { is_expected.to match_array [expert_with_custom_communes] }
       end
 
-      describe 'without_custom_zone' do
-        subject { Expert.without_custom_zone }
+      describe 'without_custom_communes' do
+        subject { Expert.without_custom_communes }
 
-        it { is_expected.to match_array [expert_without_custom_zone] }
+        it { is_expected.to match_array [expert_without_custom_communes] }
       end
     end
   end


### PR DESCRIPTION
Display intervention zones as portions of “Bassin d’emploi” instead of raw lists of insee_codes.