### PR TITLE
More admin improvements

### DIFF
--- a/app/admin/antenne.rb
+++ b/app/admin/antenne.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register Antenne do
   menu parent: :experts, priority: 1
-  includes :institution, :communes, :experts, :users
+  includes :institution, :communes, :territories, :experts, :users
 
   permit_params [
     :name,
@@ -22,7 +22,7 @@ ActiveAdmin.register Antenne do
     column :institution
     column :experts, :experts_count
     column :users, :users_count
-    column(:communes) { |a| a.communes.size }
+    column(:communes) { |a| intervention_zone_short_description(a) }
     # The two following lines are actually “N+1 requests” expensive
     # We’ll probably want to remove them or use some counter at some point.
     column(I18n.t('attributes.match_sent.other')) { |a| "#{a.sent_matches.size}" }

--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -2,7 +2,7 @@
 
 ActiveAdmin.register Expert do
   menu priority: 6
-  includes :antenne, :institution, :communes, :assistances, :users
+  includes :antenne, :institution, :communes, :territories, :assistances, :users
 
   permit_params [
     :full_name,
@@ -38,7 +38,7 @@ ActiveAdmin.register Expert do
     column :institution
     column :antenne
     column :custom_communes?
-    column(:communes) { |expert| expert.communes.size }
+    column(:communes) { |expert| intervention_zone_short_description(expert) if expert.custom_communes? }
     column(:users) { |expert| expert.users.size }
     column :role
     column :email

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -21,14 +21,21 @@ ActiveAdmin.register User do
 
   includes :experts, :relays, :territories, :antenne
 
+  # Index
+  #
   scope :all, default: true
   scopes = [:admin, :contact_relays, :without_antenne, ]
   scopes.each do |s|
     scope I18n.t("active_admin.user.scopes.#{s}"), s
   end
 
-  # Index
-  #
+  filter :full_name
+  filter :email
+  filter :institution
+  filter :role
+  filter :is_approved
+  filter :is_admin
+
   index do
     selectable_column
     id_column
@@ -72,14 +79,6 @@ ActiveAdmin.register User do
       item t('active_admin.person.normalize_values'), normalize_values_admin_user_path(user)
     end
   end
-
-  filter :full_name
-  filter :email
-  filter :institution
-  filter :role
-  filter :phone_number
-  filter :is_approved
-  filter :is_admin
 
   # Show
   #

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -33,6 +33,7 @@ ActiveAdmin.register User do
   filter :email
   filter :institution
   filter :role
+  filter :confirmed_at_not_null, as: :boolean, label: "Confirmé"
   filter :is_approved
   filter :is_admin
 
@@ -58,7 +59,7 @@ ActiveAdmin.register User do
         '-'
       end
     end
-    column(:territories) do |user|
+    column(:relays) do |user|
       if user.territories.present?
         safe_join(user.territories.map { |territory| link_to(territory.name, admin_territory_path(territory)) }, ', '.html_safe)
       else
@@ -66,8 +67,8 @@ ActiveAdmin.register User do
       end
     end
     column :created_at
+    column :confirmed?
     column :is_approved
-    column :sign_in_count
     actions dropdown: true do |user|
       if !user.is_approved?
         item(t('active_admin.user.approve_user'), approve_user_admin_user_path(user), method: :post)
@@ -119,7 +120,7 @@ ActiveAdmin.register User do
   sidebar I18n.t('active_admin.user.connection'), only: :show do
     attributes_table_for user do
       row :created_at
-      row :confirmed_at
+      row :confirmed?
       row :is_approved
       row :current_sign_in_at
       row :current_sign_in_ip

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -12,4 +12,11 @@ module AdminHelper
     end
     descriptions.join("<br/>").html_safe
   end
+
+  def intervention_zone_short_description(many_communes)
+    communes = many_communes.communes
+    territories = many_communes.territories
+    "#{territories.size} #{t('activerecord.models.territory', count: territories.size)} "\
+    "(#{communes.size} #{t('activerecord.models.commune', count: communes.size)})"
+  end
 end

--- a/app/models/concerns/many_communes.rb
+++ b/app/models/concerns/many_communes.rb
@@ -4,7 +4,7 @@ module ManyCommunes
     ## Relations and Validations
     #
     has_and_belongs_to_many :communes
-    has_many :territories, through: :communes
+    has_many :territories, -> { distinct.bassins_emploi }, through: :communes
 
     ## Insee Codes acccessors
     #

--- a/config/locales/active_record.fr.yml
+++ b/config/locales/active_record.fr.yml
@@ -170,6 +170,9 @@ fr:
       comment:
         one: Commentaire
         other: Commentaires
+      commune:
+        one: Commune
+        other: Communes
       company:
         one: Entreprise
         other: Entreprises


### PR DESCRIPTION
* Display a short summary of the intervention zone of Antennes and Experts in admin index pages
* Improve performance of intervention_zone_description
* Allow filtering out users with unconfirmed emails