### PR TITLE
Remove unused scopes

### DIFF
--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -2,7 +2,7 @@
 
 class DiagnosesController < ApplicationController
   def index
-    @diagnoses = current_user.sent_diagnoses.only_active.reverse_chronological
+    @diagnoses = current_user.sent_diagnoses.only_active.order(created_at: :desc)
       .distinct
       .left_outer_joins(:matches,
         diagnosed_needs: :matches)

--- a/app/models/assistance.rb
+++ b/app/models/assistance.rb
@@ -17,12 +17,6 @@ class Assistance < ApplicationRecord
   #
   has_one :category, through: :question, inverse_of: :assistances
 
-  ## Scopes
-  #
-  scope :of_diagnosis, (lambda do |diagnosis|
-    joins(question: :diagnosed_needs).merge(DiagnosedNeed.of_diagnosis(diagnosis))
-  end)
-
   ##
   #
   attr_accessor :filtered_assistances_experts

--- a/app/models/assistance_expert.rb
+++ b/app/models/assistance_expert.rb
@@ -3,5 +3,5 @@
 class AssistanceExpert < ApplicationRecord
   belongs_to :assistance
   belongs_to :expert
-  has_many :matches, -> { ordered_by_date }, foreign_key: :assistances_experts_id, dependent: :nullify, inverse_of: :assistance_expert
+  has_many :matches, foreign_key: :assistances_experts_id, dependent: :nullify, inverse_of: :assistance_expert
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -20,8 +20,6 @@ class Company < ApplicationRecord
 
   ## Scopes
   #
-  scope :ordered_by_name, (-> { order(:name) })
-
   scope :diagnosed_in, (lambda do |date_range|
     joins(facilities: [visits: :diagnosis])
     .where(facilities: { visits: { happened_on: date_range } })

--- a/app/models/concerns/many_communes.rb
+++ b/app/models/concerns/many_communes.rb
@@ -26,7 +26,7 @@ module ManyCommunes
     self_communes = communes.pluck(:id)
     territories_covered = []
     remaining_communes = self_communes.clone
-    self.territories.bassins_emploi.distinct.includes(:communes).ordered_by_name.each do |territory|
+    self.territories.bassins_emploi.distinct.includes(:communes).order(:name).each do |territory|
       territory_communes = territory.communes.pluck(:id)
       territory_communes_in_self = territory_communes & self_communes
       if territory_communes_in_self.size > 0

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -13,10 +13,6 @@ class Contact < ApplicationRecord
   validates :company, presence: true
   validates_with ContactValidator
 
-  ## Scopes
-  #
-  scope :ordered_by_names, (-> { order(:full_name) })
-
   ##
   #
   def can_be_viewed_by?(role)

--- a/app/models/diagnosed_need.rb
+++ b/app/models/diagnosed_need.rb
@@ -38,10 +38,6 @@ class DiagnosedNeed < ApplicationRecord
   ## Scopes
   #
   scope :of_relay_or_expert, (-> (relay_or_expert) { joins(:matches).merge(Match.of_relay_or_expert(relay_or_expert)) })
-  scope :sent_by, -> (users) {
-    joins(diagnosis: [visit: :advisor])
-      .where(diagnoses: { visits: { advisor: users } })
-  }
 
   scope :with_at_least_one_expert_done, -> { done }
 

--- a/app/models/diagnosed_need.rb
+++ b/app/models/diagnosed_need.rb
@@ -37,7 +37,6 @@ class DiagnosedNeed < ApplicationRecord
 
   ## Scopes
   #
-  scope :of_diagnosis, (-> (diagnosis) { where(diagnosis: diagnosis) })
   scope :of_question, (-> (question) { where(question: question) })
   scope :of_relay_or_expert, (-> (relay_or_expert) { joins(:matches).merge(Match.of_relay_or_expert(relay_or_expert)) })
   scope :sent_by, -> (users) {

--- a/app/models/diagnosed_need.rb
+++ b/app/models/diagnosed_need.rb
@@ -5,7 +5,7 @@ class DiagnosedNeed < ApplicationRecord
   #
   belongs_to :diagnosis, inverse_of: :diagnosed_needs
   belongs_to :question, inverse_of: :diagnosed_needs
-  has_many :matches, -> { ordered_by_date }, dependent: :destroy, inverse_of: :diagnosed_need
+  has_many :matches, dependent: :destroy, inverse_of: :diagnosed_need
 
   ## Validations
   #

--- a/app/models/diagnosed_need.rb
+++ b/app/models/diagnosed_need.rb
@@ -37,7 +37,6 @@ class DiagnosedNeed < ApplicationRecord
 
   ## Scopes
   #
-  scope :of_question, (-> (question) { where(question: question) })
   scope :of_relay_or_expert, (-> (relay_or_expert) { joins(:matches).merge(Match.of_relay_or_expert(relay_or_expert)) })
   scope :sent_by, -> (users) {
     joins(diagnosis: [visit: :advisor])

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -47,7 +47,6 @@ class Diagnosis < ApplicationRecord
   scope :reverse_chronological, (-> { order(created_at: :desc) })
   scope :in_progress, (-> { where(step: [1..LAST_STEP - 1]) })
   scope :completed, (-> { where(step: LAST_STEP) })
-  scope :of_facilities, (-> (facilities) { joins(:visit).merge(Visit.where(facility: facilities)) })
   scope :available_for_expert, (lambda do |expert|
     joins(diagnosed_needs: [matches: [assistance_expert: :expert]])
       .where(diagnosed_needs: { matches: { assistance_expert: { experts: { id: expert.id } } } })

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -47,7 +47,6 @@ class Diagnosis < ApplicationRecord
   scope :reverse_chronological, (-> { order(created_at: :desc) })
   scope :in_progress, (-> { where(step: [1..LAST_STEP - 1]) })
   scope :completed, (-> { where(step: LAST_STEP) })
-  scope :in_territory, (-> (territory) { of_facilities(Facility.in_territory(territory)) })
   scope :of_facilities, (-> (facilities) { joins(:visit).merge(Visit.where(facility: facilities)) })
   scope :available_for_expert, (lambda do |expert|
     joins(diagnosed_needs: [matches: [assistance_expert: :expert]])

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -42,7 +42,6 @@ class Diagnosis < ApplicationRecord
 
   ## Scopes
   #
-  scope :of_siret, (-> (siret) { joins(:visit).merge(Visit.of_siret(siret)) })
   scope :of_user, (-> (user) { joins(:visit).where(visits: { advisor: user }) })
   scope :reverse_chronological, (-> { order(created_at: :desc) })
   scope :in_progress, (-> { where(step: [1..LAST_STEP - 1]) })

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -43,7 +43,6 @@ class Diagnosis < ApplicationRecord
   ## Scopes
   #
   scope :of_user, (-> (user) { joins(:visit).where(visits: { advisor: user }) })
-  scope :reverse_chronological, (-> { order(created_at: :desc) })
   scope :in_progress, (-> { where(step: [1..LAST_STEP - 1]) })
   scope :completed, (-> { where(step: LAST_STEP) })
   scope :available_for_expert, (lambda do |expert|

--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -30,7 +30,7 @@ class Diagnosis < ApplicationRecord
 
   # :diagnosed_needs
   has_many :questions, through: :diagnosed_needs, inverse_of: :diagnoses
-  has_many :matches, -> { ordered_by_date }, through: :diagnosed_needs, inverse_of: :diagnosis
+  has_many :matches, through: :diagnosed_needs, inverse_of: :diagnosis
 
   # :matches
   has_many :experts, through: :matches, inverse_of: :received_diagnoses

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -47,7 +47,6 @@ class Expert < ApplicationRecord
     joins(:antenne_institution).merge(Institution.of_naf_code(naf_code))
   end
 
-  scope :ordered_by_names, -> { order(:full_name) }
   scope :ordered_by_institution, -> do
     joins(:antenne, :antenne_institution)
       .select('experts.*', 'antennes.name', 'institutions.name')

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -15,7 +15,7 @@ class Expert < ApplicationRecord
 
   has_many :assistances_experts, dependent: :destroy
   has_many :assistances, through: :assistances_experts, dependent: :destroy, inverse_of: :experts # TODO should be direct once we remove the AssistanceExpert model and use a HABTM
-  has_many :received_matches, -> { ordered_by_date }, through: :assistances_experts, source: :matches, inverse_of: :expert # TODO should be direct once we remove the AssistanceExpert model and use a HABTM
+  has_many :received_matches, through: :assistances_experts, source: :matches, inverse_of: :expert # TODO should be direct once we remove the AssistanceExpert model and use a HABTM
 
   ## Validations
   #

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -23,10 +23,6 @@ class Facility < ApplicationRecord
   # :commune
   has_many :territories, through: :commune, inverse_of: :facilities
 
-  ## Scopes
-  #
-  scope :in_territory, (-> (territory) { where(commune: territory.communes) })
-
   ##
   #
   def to_s

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -29,7 +29,6 @@ class Institution < ApplicationRecord
   end)
   scope :qualified_for_artisanry, (-> { where(qualified_for_artisanry: true) })
   scope :qualified_for_commerce, (-> { where(qualified_for_commerce: true) })
-  scope :ordered_by_name, (-> { order(:name) })
 
   ##
   #

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -63,7 +63,6 @@ class Match < ApplicationRecord
   scope :updated_more_than_five_days_ago, (-> { where('updated_at < ?', 5.days.ago) })
   scope :needing_taking_care_update, (-> { with_status(:taking_care).updated_more_than_five_days_ago })
 
-  scope :in_territory, (-> (territory) { of_diagnoses(Diagnosis.in_territory(territory)) })
   scope :of_facilities, (-> (facilities) { of_diagnoses(Diagnosis.of_facilities(facilities)) })
 
   scope :of_relay_or_expert, (lambda do |relay_or_expert|

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -80,11 +80,6 @@ class Match < ApplicationRecord
     end
   end)
 
-  scope :sent_by, -> (users) {
-    joins(diagnosis: [visit: :advisor])
-      .where(diagnoses: { visits: { advisor: users } })
-  }
-
   ##
   #
   def to_s

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -54,8 +54,6 @@ class Match < ApplicationRecord
 
   ## Scopes
   #
-  scope :ordered_by_date, -> { order(created_at: :desc) }
-
   scope :not_viewed, (-> { where(expert_viewed_page_at: nil) })
 
   scope :of_diagnoses, (lambda do |diagnoses|

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -63,8 +63,6 @@ class Match < ApplicationRecord
   scope :updated_more_than_five_days_ago, (-> { where('updated_at < ?', 5.days.ago) })
   scope :needing_taking_care_update, (-> { with_status(:taking_care).updated_more_than_five_days_ago })
 
-  scope :of_facilities, (-> (facilities) { of_diagnoses(Diagnosis.of_facilities(facilities)) })
-
   scope :of_relay_or_expert, (lambda do |relay_or_expert|
     if relay_or_expert.is_a?(Enumerable)
       if relay_or_expert.empty?

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -3,7 +3,7 @@
 class Relay < ApplicationRecord
   belongs_to :territory
   belongs_to :user
-  has_many :matches, -> { ordered_by_date }, dependent: :nullify, inverse_of: :relay
+  has_many :matches, dependent: :nullify, inverse_of: :relay
 
   validates :territory, :user, presence: true
   validates :territory, uniqueness: { scope: :user }

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -9,12 +9,4 @@ class Relay < ApplicationRecord
   validates :territory, uniqueness: { scope: :user }
 
   scope :of_user, (-> (user) { where(user: user) })
-
-  def territory_diagnoses
-    Diagnosis.only_active
-      .includes(visit: [:advisor, facility: [:company]])
-      .includes(diagnosed_needs: [:question, :matches])
-      .in_territory(self.territory)
-      .reverse_chronological
-  end
 end

--- a/app/models/territory.rb
+++ b/app/models/territory.rb
@@ -26,7 +26,6 @@ class Territory < ApplicationRecord
 
   ## Scopes
   #
-  scope :ordered_by_name, -> { order(:name) }
   scope :bassins_emploi, -> { where(bassin_emploi: true) }
 
   ##

--- a/app/models/use_cases/get_diagnosed_needs_with_filtered_assistance_experts.rb
+++ b/app/models/use_cases/get_diagnosed_needs_with_filtered_assistance_experts.rb
@@ -5,7 +5,7 @@ module UseCases
     class << self
       def of_diagnosis(diagnosis)
         inclusions = [question: [assistances: [assistances_experts: [expert: :antenne_institution]]]]
-        diagnosed_needs = DiagnosedNeed.of_diagnosis(diagnosis).includes(inclusions)
+        diagnosed_needs = diagnosis.diagnosed_needs.includes(inclusions)
         diagnosed_needs = diagnosed_needs.ordered_by_interview
         select_localized_and_business_assistance_experts(diagnosed_needs, diagnosis)
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,7 +67,6 @@ class User < ApplicationRecord
   scope :not_approved, -> { where(is_approved: false) }
   scope :email_not_confirmed, -> { where(confirmed_at: nil) }
 
-  scope :ordered_by_names, -> { order(:full_name) }
   scope :ordered_by_institution, -> do
     joins(:antenne, :antenne_institution)
       .select('users.*', 'antennes.name', 'institutions.name')

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -13,8 +13,6 @@ class Visit < ApplicationRecord
 
   validates :advisor, :facility, presence: true
 
-  scope :of_siret, (-> (siret) { joins(:facility).where(facilities: { siret: siret }) })
-
   def to_s
     "#{company_name} (#{I18n.l display_date})"
   end

--- a/app/services/admin_mailers_service.rb
+++ b/app/services/admin_mailers_service.rb
@@ -8,7 +8,7 @@ class AdminMailersService
       @information_hash = {}
 
       associations = [visit: [:advisor, facility: [:company]]]
-      @not_admin_diagnoses = Diagnosis.includes(associations).only_active.of_user(User.not_admin).reverse_chronological
+      @not_admin_diagnoses = Diagnosis.includes(associations).only_active.of_user(User.not_admin).order(created_at: :desc)
       @completed_diagnoses = @not_admin_diagnoses.completed.updated_last_week
 
       sign_up_statistics

--- a/app/services/relay_service/mailer_service.rb
+++ b/app/services/relay_service/mailer_service.rb
@@ -10,8 +10,6 @@ module RelayService
         end
       end
 
-      private
-
       def send_relay_stats_email_to(relay)
         diagnoses = relay.territory_diagnoses
 

--- a/app/services/relay_service/mailer_service.rb
+++ b/app/services/relay_service/mailer_service.rb
@@ -11,7 +11,7 @@ module RelayService
       end
 
       def send_relay_stats_email_to(relay)
-        diagnoses = relay.territory.diagnoses.reverse_chronological
+        diagnoses = relay.territory.diagnoses.order(created_at: :desc)
 
         information_hash = generate_statistics_hash diagnoses
         stats_csv = RelayService::CSVGenerator.generate_statistics_csv(diagnoses)

--- a/app/services/relay_service/mailer_service.rb
+++ b/app/services/relay_service/mailer_service.rb
@@ -11,7 +11,7 @@ module RelayService
       end
 
       def send_relay_stats_email_to(relay)
-        diagnoses = relay.territory_diagnoses
+        diagnoses = relay.territory.diagnoses.reverse_chronological
 
         information_hash = generate_statistics_hash diagnoses
         stats_csv = RelayService::CSVGenerator.generate_statistics_csv(diagnoses)

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -1,7 +1,7 @@
 class AdminMailerPreview < ActionMailer::Preview
   def weekly_statistics
     associations = [visit: [:advisor, facility: [:company]]]
-    @not_admin_diagnoses = Diagnosis.includes(associations).only_active.of_user(User.not_admin).reverse_chronological
+    @not_admin_diagnoses = Diagnosis.includes(associations).only_active.of_user(User.not_admin).order(created_at: :desc)
     @completed_diagnoses = @not_admin_diagnoses.completed.updated_last_week
     created_diagnoses = @not_admin_diagnoses.in_progress.created_last_week
 

--- a/spec/mailers/previews/relay_mailer_preview.rb
+++ b/spec/mailers/previews/relay_mailer_preview.rb
@@ -1,0 +1,10 @@
+class RelayMailerPreview < ActionMailer::Preview
+  def weekly_statistics
+    relay = Territory.find(29).relays.first
+
+    diagnoses = relay.territory.diagnoses.reverse_chronological
+    information_hash = RelayService::MailerService::generate_statistics_hash diagnoses
+    stats_csv = RelayService::CSVGenerator.generate_statistics_csv(diagnoses)
+    RelayMailer.weekly_statistics(relay, information_hash, stats_csv)
+  end
+end

--- a/spec/mailers/previews/relay_mailer_preview.rb
+++ b/spec/mailers/previews/relay_mailer_preview.rb
@@ -2,7 +2,7 @@ class RelayMailerPreview < ActionMailer::Preview
   def weekly_statistics
     relay = Territory.find(29).relays.first
 
-    diagnoses = relay.territory.diagnoses.reverse_chronological
+    diagnoses = relay.territory.diagnoses.order(created_at: :desc)
     information_hash = RelayService::MailerService::generate_statistics_hash diagnoses
     stats_csv = RelayService::CSVGenerator.generate_statistics_csv(diagnoses)
     RelayMailer.weekly_statistics(relay, information_hash, stats_csv)

--- a/spec/models/assistance_spec.rb
+++ b/spec/models/assistance_spec.rb
@@ -20,32 +20,4 @@ RSpec.describe Assistance, type: :model do
       expect(assistance.filtered_assistances_experts).to be_nil
     end
   end
-
-  describe 'scopes' do
-    describe 'of_diagnosis' do
-      subject { Assistance.of_diagnosis diagnosis }
-
-      let(:diagnosis) { create :diagnosis }
-      let(:question) { create :question }
-
-      before { create :diagnosed_need, diagnosis: diagnosis, question: question }
-
-      context 'one assistance' do
-        let!(:assistance) { create :assistance, question: question }
-
-        it { is_expected.to eq [assistance] }
-      end
-
-      context 'several assistances' do
-        let!(:assistance) { create :assistance, question: question }
-        let!(:assistance2) { create :assistance, question: question }
-
-        it { is_expected.to match_array [assistance, assistance2] }
-      end
-
-      context 'no assistance' do
-        it { is_expected.to be_empty }
-      end
-    end
-  end
 end

--- a/spec/models/diagnosed_need_spec.rb
+++ b/spec/models/diagnosed_need_spec.rb
@@ -87,15 +87,6 @@ RSpec.describe DiagnosedNeed, type: :model do
   end
 
   describe 'scopes' do
-    describe 'of_question' do
-      subject { DiagnosedNeed.of_question question }
-
-      let(:question) { create :question }
-      let(:diagnosed_need) { create :diagnosed_need, question: question }
-
-      it { is_expected.to eq [diagnosed_need] }
-    end
-
     describe 'with_at_least_one_expert_done' do
       subject { DiagnosedNeed.with_at_least_one_expert_done }
 

--- a/spec/models/diagnosed_need_spec.rb
+++ b/spec/models/diagnosed_need_spec.rb
@@ -87,15 +87,6 @@ RSpec.describe DiagnosedNeed, type: :model do
   end
 
   describe 'scopes' do
-    describe 'of_diagnosis' do
-      subject { DiagnosedNeed.of_diagnosis diagnosis }
-
-      let(:diagnosis) { create :diagnosis }
-      let(:diagnosed_need) { create :diagnosed_need, diagnosis: diagnosis }
-
-      it { is_expected.to eq [diagnosed_need] }
-    end
-
     describe 'of_question' do
       subject { DiagnosedNeed.of_question question }
 

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -55,31 +55,6 @@ RSpec.describe Diagnosis, type: :model do
       end
     end
 
-    describe 'reverse_chronological' do
-      subject { Diagnosis.reverse_chronological }
-
-      context 'no diagnosis' do
-        it { is_expected.to eq [] }
-      end
-
-      context 'only one diagnosis' do
-        it do
-          diagnosis = create :diagnosis
-
-          is_expected.to eq [diagnosis]
-        end
-      end
-
-      context 'two diagnoses' do
-        it do
-          diagnosis1 = create :diagnosis, created_at: 3.days.ago
-          diagnosis2 = create :diagnosis, created_at: 1.day.ago
-
-          is_expected.to eq [diagnosis2, diagnosis1]
-        end
-      end
-    end
-
     describe 'in progress' do
       subject { Diagnosis.in_progress.count }
 

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -152,26 +152,6 @@ RSpec.describe Diagnosis, type: :model do
       end
     end
 
-    describe 'in_territory' do
-      subject { Diagnosis.in_territory territory }
-
-      let(:territory) { create :territory }
-      let(:commune) { create :commune }
-      let(:facility) { create :facility, commune: commune }
-      let(:visit) { create :visit, facility: facility }
-      let!(:diagnosis) { create :diagnosis, visit: visit }
-
-      context 'with territory cities' do
-        before { territory.communes = [commune] }
-
-        it { is_expected.to eq [diagnosis] }
-      end
-
-      context 'without territory city' do
-        it { is_expected.to eq [] }
-      end
-    end
-
     describe 'available_for_expert' do
       subject { Diagnosis.available_for_expert(expert) }
 

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -25,26 +25,6 @@ RSpec.describe Diagnosis, type: :model do
   end
 
   describe 'scopes' do
-    describe 'of_siret' do
-      subject { Diagnosis.of_siret siret }
-
-      let(:visit) { build :visit, facility: facility }
-      let(:facility) { create :facility }
-      let(:siret) { facility.siret }
-
-      context 'no diagnosis' do
-        it { is_expected.to eq [] }
-      end
-
-      context 'only one diagnosis' do
-        it do
-          diagnosis = create :diagnosis, visit: visit
-
-          is_expected.to eq [diagnosis]
-        end
-      end
-    end
-
     describe 'of_user' do
       subject { Diagnosis.of_user user }
 

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -14,26 +14,6 @@ RSpec.describe Facility, type: :model do
     end
   end
 
-  describe 'scopes' do
-    describe 'in_territory' do
-      subject { Facility.in_territory territory }
-
-      let(:territory) { create :territory }
-      let(:facility) { create :facility, commune: commune }
-      let(:commune) { create :commune, insee_code: '59001' }
-
-      context 'with territory cities' do
-        before { territory.communes << commune }
-
-        it { is_expected.to eq [facility] }
-      end
-
-      context 'without territory city' do
-        it { is_expected.to eq [] }
-      end
-    end
-  end
-
   describe 'to_s' do
     subject { facility.to_s }
 

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -14,28 +14,6 @@ RSpec.describe Visit, type: :model do
     end
   end
 
-  describe 'scopes' do
-    describe 'of_siret' do
-      subject { Visit.of_siret facility.siret }
-
-      let(:facility) { create :facility, siret: '44622002200229' }
-
-      context 'visit exists' do
-        it do
-          visit = create :visit, facility: facility
-          is_expected.to eq [visit]
-        end
-      end
-
-      context 'visit does not exist' do
-        it do
-          create :visit
-          is_expected.to be_empty
-        end
-      end
-    end
-  end
-
   describe 'company_name' do
     it do
       name = 'Octo'


### PR DESCRIPTION
Following #293, just use associations through models instead of using custom scopes.

This is only partially done, but it already accounts for `+21, -216` lines.