### PR TITLE
Don’t include google fonts (in semantic-ui)

### DIFF
--- a/app/assets/stylesheets/layout.sass
+++ b/app/assets/stylesheets/layout.sass
@@ -1,4 +1,6 @@
+$import-google-fonts: false
 @import semantic-ui
+@import semantic-ui-calendar.min
 
 @media (min-width: 767px)
   .main.container

--- a/app/assets/stylesheets/semantic-ui_extensions.sass
+++ b/app/assets/stylesheets/semantic-ui_extensions.sass
@@ -1,6 +1,4 @@
-@import semantic-ui
 @import compass/css3/box-shadow
-@import semantic-ui-calendar.min
 
 .ui.segment.shadow-less
   box-shadow: none


### PR DESCRIPTION
Let’s just use the default (Helvetica / sans-serif).