### PR TITLE
Use ujs / turbolinks more consistently

### DIFF
--- a/app/helpers/needs_helper.rb
+++ b/app/helpers/needs_helper.rb
@@ -4,6 +4,6 @@ module NeedsHelper
   def link_to_match_path(title, match, new_status, css_classes)
     classes = %w[ui button tiny] + css_classes
     token = params[:access_token]
-    link_to title, match_path(match.id, access_token: token), data: { remote: true, method: :patch, params: { status: new_status } }, class: classes.join(' ')
+    link_to title, match_path(match.id, access_token: token, status: new_status), data: { remote: true, method: :patch }, class: classes.join(' ')
   end
 end

--- a/app/views/diagnoses/_steps.html.haml
+++ b/app/views/diagnoses/_steps.html.haml
@@ -4,5 +4,5 @@
       - class_for_step = html_classes_for_step(displayed_step, current_page_step, diagnosis_step)
       .step{ class: class_for_step }
         .content
-          .title{ data: { turbolinks: 'false' } }
+          .title
             = t(".step#{displayed_step}_title_html")

--- a/app/views/diagnoses/step2.html.haml
+++ b/app/views/diagnoses/step2.html.haml
@@ -3,8 +3,10 @@
 = render partial: 'steps', locals: { current_page_step: 2, diagnosis_step: @diagnosis.step }
 
 #step2-app
-  = form_for @diagnosis, url: besoins_diagnosis_path(@diagnosis), method: :post,
-                 html: { class: 'ui form diagnosis_form' } do |diagnosis_form|
+  = form_with model: @diagnosis,
+    url: besoins_diagnosis_path(@diagnosis),
+    method: :post,
+    class: 'ui form diagnosis_form' do |diagnosis_form|
 
     %h1.ui.header
       = t('.title')

--- a/app/views/diagnoses/step3.html.haml
+++ b/app/views/diagnoses/step3.html.haml
@@ -3,8 +3,11 @@
 = render partial: 'steps', locals: { current_page_step: 3, diagnosis_step: @diagnosis.step }
 
 #step3-app
-  = form_for @diagnosis, url: visite_diagnosis_path(@diagnosis), method: :post,
-                 html: { class: 'ui form' } do |diagnosis_form|
+  = form_with model: @diagnosis,
+    url: visite_diagnosis_path(@diagnosis),
+    method: :post,
+    class: 'ui form' do |diagnosis_form|
+
     %h2.ui.header
       .sub.header
         = t('.form_info')


### PR DESCRIPTION
Following #309: replace some `form_for` with `form_with` and use turbolinks between diagnoses steps.

This _may_ also include a fix for https://trello.com/c/VovU4pzW/277-les-boutons-de-prise-en-charge-ne-fonctionnent-pas-chez-certains-référents