### PR TITLE
Workaround memory leaks active admin

### DIFF
--- a/app/admin/antenne.rb
+++ b/app/admin/antenne.rb
@@ -19,6 +19,10 @@ ActiveAdmin.register Antenne do
       div admin_link_to(a, :advisors)
       div admin_link_to(a, :experts)
     end
+    column(:intervention_zone) do |a|
+      div admin_link_to(a, :territories)
+      div admin_link_to(a, :communes)
+    end
     column(:activity) do |a|
       div admin_link_to(a, :sent_matches)
       div admin_link_to(a, :received_matches)

--- a/app/admin/expert.rb
+++ b/app/admin/expert.rb
@@ -23,6 +23,14 @@ ActiveAdmin.register Expert do
       div admin_link_to(e, :antenne_institution)
       div admin_link_to(e, :antenne)
     end
+    column(:intervention_zone) do |e|
+      if e.custom_communes?
+        status_tag t('attributes.custom_communes'), class: 'yes'
+      end
+      zone = e.custom_communes? ? e : e.antenne
+      div admin_link_to(zone, :territories)
+      div admin_link_to(zone, :communes)
+    end
     column(:users) do |e|
       div admin_link_to(e, :users)
     end

--- a/app/admin/territory.rb
+++ b/app/admin/territory.rb
@@ -5,7 +5,8 @@ ActiveAdmin.register Territory do
 
   ## index
   #
-  includes :communes, :relay_users, :antennes, :advisors, :antenne_experts, :diagnoses, :diagnosed_needs, :matches
+  # Note: Don’t `includes` related tables, as this causes massive leaks in ActiveAdmin.
+  # Since we only have a few dozens entries, N+1 queries are preferred.
   config.sort_order = 'name_asc'
 
   scope :all, default: true


### PR DESCRIPTION
ActiveAdmin leaks 100M+ each request `/admin/territories`. My current analysis is that each object is actually instantiated, which means _a lot_ in the case of communes. If we simply avoid `:communes` in the `includes`, we get N+1 queries, but since there’s only a few dozens entries, this is preferred.

Similarly (following #303), we can readd the `intervention zone` columns in Antenne and Experts.