### PR TITLE
Allow editing relays in admin

### DIFF
--- a/app/admin/territory.rb
+++ b/app/admin/territory.rb
@@ -62,14 +62,17 @@ ActiveAdmin.register Territory do
       row :bassin_emploi
       row(:communes) do |t|
         div admin_link_to(t, :communes)
-        safe_join(t.communes.map { |c| admin_link_to c }, ', '.html_safe)
+        div safe_join(t.communes.map { |c| admin_link_to c }, ', '.html_safe)
+      end
+      row(:relay_users) do |t|
+        div admin_link_to(t, :relay_users)
+        div admin_link_to(t, :relay_users, list: true)
       end
       row(:antennes) do |t|
-        safe_join(t.antennes.distinct.map { |a| admin_link_to a }, ', '.html_safe)
+        div admin_link_to(t, :antennes)
+        div safe_join(t.antennes.distinct.map { |a| admin_link_to a }, ', '.html_safe)
       end
       row(:community) do |t|
-        div admin_link_to(t, :relay_users)
-        div admin_link_to(t, :antennes)
         div admin_link_to(t, :advisors)
         div admin_link_to(t, :antenne_experts)
       end
@@ -83,7 +86,7 @@ ActiveAdmin.register Territory do
 
   ## Form
   #
-  permit_params :name, :insee_codes
+  permit_params :name, :insee_codes, :bassin_emploi, relay_user_ids: []
 
   form do |f|
     f.inputs do
@@ -92,6 +95,9 @@ ActiveAdmin.register Territory do
     end
     f.inputs do
       f.input :insee_codes
+    end
+    f.inputs do
+      f.input :relay_users, as: :ajax_select, data: { url: :admin_users_path, search_fields: [:full_name], limit: 999 }
     end
 
     f.actions

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -11,7 +11,7 @@ ActiveAdmin.register User do
 
   scope :all, default: true
   scope :admin
-  scope :contact_relays
+  scope :relays
   scope :without_antenne
   scope :not_approved
   scope :email_not_confirmed

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -115,7 +115,7 @@ ActiveAdmin.register User do
           link_to(text, autolink_to_experts_admin_user_path(u), method: :post)
         end
       end
-      row :relays_territories do |u|
+      row :relay_territories do |u|
         div admin_link_to(u, :relay_territories, list: true)
       end
       row :activity do |u|
@@ -158,7 +158,7 @@ ActiveAdmin.register User do
   permit_params :full_name, :email, :institution, :role, :phone_number, :is_approved,
     :contact_page_order, :contact_page_role,
     :is_admin, :password, :password_confirmation,
-    :antenne_id, expert_ids: []
+    :antenne_id, expert_ids: [], relay_territory_ids: []
 
   form do |f|
     f.inputs I18n.t('active_admin.user.user_info') do
@@ -177,6 +177,14 @@ ActiveAdmin.register User do
       f.input :role
       f.input :email
       f.input :phone_number
+    end
+
+    f.inputs do
+      f.input :relay_territories, as: :ajax_select, data: {
+        url: :admin_territories_path,
+        search_fields: [:name],
+        limit: 999
+      }
     end
 
     f.inputs I18n.t('active_admin.user.connection') do

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -11,7 +11,7 @@ class HomeController < ApplicationController
   def cgu; end
 
   def contact
-    @relays = User.contact_relays
-    @product_team = User.with_contact_page_order
+    @relays = User.relays.ordered_for_contact
+    @product_team = User.project_team.ordered_for_contact.uniq
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,20 +53,19 @@ class User < ApplicationRecord
 
   ## Scopes
   #
-  scope :with_contact_page_order, (-> { where.not(contact_page_order: nil).order(:contact_page_order) })
-  scope :contact_relays, (lambda do
-    not_admin
-      .joins(:relays)
-      .includes(relays: :territory)
-      .order('territories.name', :contact_page_order, :full_name)
-      .distinct
-  end)
   scope :admin, (-> { where(is_admin: true) })
   scope :not_admin, (-> { where(is_admin: false) })
   scope :approved, -> { where(is_approved: true) }
   scope :not_approved, -> { where(is_approved: false) }
   scope :email_not_confirmed, -> { where(confirmed_at: nil) }
+  scope :project_team, -> { admin.where.not(contact_page_order: nil) }
+  scope :relays, -> { not_admin.joins(:relays).distinct }
 
+  scope :ordered_for_contact, -> {
+    left_outer_joins(:relay_territories)
+      .select('users.*, territories.name')
+      .order('territories.name', :contact_page_order, :full_name)
+  }
   scope :ordered_by_institution, -> do
     joins(:antenne, :antenne_institution)
       .select('users.*', 'antennes.name', 'institutions.name')

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -14,10 +14,10 @@ fr:
       admin: Admins
       bassins_emploi: Bassins d’emploi
       being_taken_care_of: En cours
-      contact_relays: Relais locaux
       done: Résolu
       email_not_confirmed: Email non confirmé
       not_approved: Non validés
+      relays: Relais locaux
       unsent: Non envoyé
       with_custom_communes: Zone spécifique
       with_no_one_in_charge: En attente

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -49,25 +49,29 @@ RSpec.describe User, type: :model do
   end
 
   describe 'scopes' do
-    describe 'with_contact_page_order' do
+    describe 'ordered_for_contact' do
       it do
-        create :user, contact_page_order: nil
-        user_of_contact_page = create :user, contact_page_order: 1
+        user1 = create :user, contact_page_order: 1
+        create(:relay, user: user1, territory: create(:territory, name: 'aa'))
+        user2 = create :user, contact_page_order: 2
+        create(:relay, user: user2, territory: create(:territory, name: 'bb'))
+        user3 = create :user, contact_page_order: 1
+        user4 = create :user, contact_page_order: 2
 
-        expect(User.with_contact_page_order).to eq [user_of_contact_page]
+        expect(User.ordered_for_contact).to eq [user1, user2, user3, user4]
       end
     end
 
-    describe 'contact_relays' do
+    describe 'relays' do
       it do
         user1 = create :user
-        create(:relay, user: user1, territory: create(:territory, name: 'bb'))
+        create(:relay, user: user1)
         user2 = create :user
-        create(:relay, user: user2, territory: create(:territory, name: 'aa'))
+        create(:relay, user: user2)
         user3 = create :user, is_admin: true
         create :relay, user: user3
 
-        expect(User.contact_relays).to eq [user2, user1]
+        expect(User.relays).to match_array [user1, user2]
       end
     end
 


### PR DESCRIPTION
Both in territories and in users details; also fix a performance issue with loading the “relays” scope in users.