### PR TITLE
 Allow La Poste siret numbers to be recognized

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -5,7 +5,7 @@ class CompaniesController < ApplicationController
     @query = search_query
     if @query.present?
       siret = siret(@query)
-      if siret.present? && luhn(siret)
+      if siret.present? && siret_is_valid(siret)
         redirect_to company_path(siret, query: @query)
       else
         search_results
@@ -75,6 +75,10 @@ class CompaniesController < ApplicationController
   def siret(query)
     maybe_siret = query.gsub(/\s+/, '')
     maybe_siret if maybe_siret.match?(/\d{14}/)
+  end
+
+  def siret_is_valid(siret)
+    luhn(siret) || siret_is_hardcoded_valid(siret)
   end
 
   def luhn(str)

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -5,7 +5,7 @@ class CompaniesController < ApplicationController
     @query = search_query
     if @query.present?
       siret = siret(@query)
-      if siret.present? && siret_is_valid(siret)
+      if siret.present? && Facility::siret_is_valid(siret)
         redirect_to company_path(siret, query: @query)
       else
         search_results
@@ -75,24 +75,6 @@ class CompaniesController < ApplicationController
   def siret(query)
     maybe_siret = query.gsub(/\s+/, '')
     maybe_siret if maybe_siret.match?(/\d{14}/)
-  end
-
-  def siret_is_valid(siret)
-    luhn(siret) || siret_is_hardcoded_valid(siret)
-  end
-
-  def luhn(str)
-    s = str.reverse
-    sum = 0
-    (0..s.size - 1).step(2) do |k| # k is odd, k+1 is even
-      sum += s[k].to_i # s1
-      tmp = s[k + 1].to_i * 2
-      if tmp > 9
-        tmp = tmp.to_s.split(//).map(&:to_i).reduce(:+)
-      end
-      sum += tmp
-    end
-    (sum % 10).zero?
   end
 
   def save_search(query, label = nil)

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -48,6 +48,24 @@ class Facility < ApplicationRecord
   ##
   #
   class << self
+    def siret_is_valid(siret)
+      luhn_valid(siret) || siret_is_hardcoded_valid(siret)
+    end
+
+    def luhn_valid(str)
+      s = str.reverse
+      sum = 0
+      (0..s.size - 1).step(2) do |k| # k is odd, k+1 is even
+        sum += s[k].to_i # s1
+        tmp = s[k + 1].to_i * 2
+        if tmp > 9
+          tmp = tmp.to_s.split(//).map(&:to_i).reduce(:+)
+        end
+        sum += tmp
+      end
+      (sum % 10).zero?
+    end
+
     def siret_is_hardcoded_valid(siret)
       # https://fr.wikipedia.org/wiki/Système_d%27identification_du_répertoire_des_établissements
       # Pour des raisons historiques, les SIRET attribués aux établissements du groupe La Poste utilisent une autre formule de validation, et ne sont donc pas tous valides au sens de la formule de Luhn. Le groupe La Poste ayant le SIREN : 356000000, les SIRET suivant cette autre formule de validation sont de la forme 356000000XXXXX

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -47,6 +47,16 @@ class Facility < ApplicationRecord
 
   ##
   #
+  class << self
+    def siret_is_hardcoded_valid(siret)
+      # https://fr.wikipedia.org/wiki/Système_d%27identification_du_répertoire_des_établissements
+      # Pour des raisons historiques, les SIRET attribués aux établissements du groupe La Poste utilisent une autre formule de validation, et ne sont donc pas tous valides au sens de la formule de Luhn. Le groupe La Poste ayant le SIREN : 356000000, les SIRET suivant cette autre formule de validation sont de la forme 356000000XXXXX
+      siret.match?(/356000000...../)
+    end
+  end
+
+  ##
+  #
   def to_s
     "#{company.name} (#{readable_locality || commune.insee_code})"
   end


### PR DESCRIPTION
For historical reasons, the SIRET numbers of La Poste are not luhn valid.

While we’re there, clean up a bit the siret validation code, from the controller to the Facility model. Still not great, but less terrible?