### PR TITLE
Fix nonworking admin pages for institutions

### DIFF
--- a/app/admin/institution.rb
+++ b/app/admin/institution.rb
@@ -67,7 +67,8 @@ ActiveAdmin.register Institution do
     f.inputs do
       f.input :antennes, label: t('activerecord.attributes.institution.antennes'), as: :ajax_select, data: {
         url: :admin_antennes_path,
-        search_fields: [:name]
+        search_fields: [:name],
+        limit: 999
       }
     end
 


### PR DESCRIPTION
Allow editing. ActiveAdmin ajax_select inputs for to-many associations are buggy; without specifying the limit, only the first item is shown. When saving change, this tries to break the other associations, which our DB validations (hopefully) prevent.