### PR TITLE
Tweak login/logout redirect pages for the new root

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,9 +20,13 @@ class ApplicationController < ActionController::Base
     current_user.is_admin? || not_found
   end
 
-  # Devise parameter
-  def after_sign_in_path_for(_resource)
-    diagnoses_path
+  ## Devise overrides
+  def after_sign_in_path_for(resource_or_scope)
+    stored_location_for(resource_or_scope) || diagnoses_path
+  end
+
+  def after_sign_out_path_for(resource_or_scope)
+    home_index_path
   end
 
   def not_found

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -11,7 +11,7 @@ ActiveAdmin.setup do |config|
   # Set the link url for the title. For example, to take
   # users to your main site. Defaults to no link.
   #
-  config.site_title_link = '/'
+  config.site_title_link = '/diagnoses'
 
   # Set an optional image to be displayed for the header
   # instead of a string (overrides :site_title)

--- a/config/initializers/user_impersonate.rb
+++ b/config/initializers/user_impersonate.rb
@@ -19,7 +19,7 @@ module UserImpersonate
     config.user_is_staff_method = 'is_admin?'
 
     # Redirect to this path when entering impersonate mode
-    config.redirect_on_impersonate = '/'
+    config.redirect_on_impersonate = '/diagnoses'
 
     # Redirect to this path when leaving impersonate mode
     config.redirect_on_revert = '/admin/users'


### PR DESCRIPTION
* After logout, go to /home rather than /
* After a login redirect, go back to the originally requested page, if any. Otherwise, go to /diagnoses
* When impersonating, go to /diagnoses instead of /
* When clicking [Reso] from the admin, go to /diagnoses rather than /