### PR TITLE
Avoid displaying unapproved profiles in the team page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -11,7 +11,7 @@ class HomeController < ApplicationController
   def cgu; end
 
   def team
-    @relays = User.relays.ordered_for_contact
-    @product_team = User.project_team.ordered_for_contact.uniq
+    @relays = User.approved.relays.ordered_for_contact
+    @product_team = User.approved.project_team.ordered_for_contact.uniq
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,6 +103,7 @@ class User < ApplicationRecord
     left_outer_joins(:relay_territories)
       .select('users.*, territories.name')
       .order('territories.name', :contact_page_order, :full_name)
+      .distinct
   }
   scope :ordered_by_institution, -> do
     joins(:antenne, :antenne_institution)


### PR DESCRIPTION
Also, avoid displaying duplicates