### PR TITLE
Tweak SIRET validation to allow hyphens and separator

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -4,8 +4,8 @@ class CompaniesController < ApplicationController
   def search
     @query = search_query
     if @query.present?
-      siret = siret(@query)
-      if siret.present? && Facility::siret_is_valid(siret)
+      siret = Facility::siret_from_query(@query)
+      if siret.present?
         redirect_to company_path(siret, query: @query)
       else
         search_results
@@ -70,11 +70,6 @@ class CompaniesController < ApplicationController
   def search_query
     query = params['query']
     query.present? ? query.strip : nil
-  end
-
-  def siret(query)
-    maybe_siret = query.gsub(/\s+/, '')
-    maybe_siret if maybe_siret.match?(/\d{14}/)
   end
 
   def save_search(query, label = nil)

--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -48,8 +48,14 @@ class Facility < ApplicationRecord
   ##
   #
   class << self
+    def siret_from_query(query)
+      maybe_siret = query&.gsub(/[\W_]+/, '')
+      maybe_siret if siret_is_valid(maybe_siret)
+    end
+
     def siret_is_valid(siret)
-      luhn_valid(siret) || siret_is_hardcoded_valid(siret)
+      siret.present? && siret.match?(/^\d{14}$/) &&
+        (luhn_valid(siret) || siret_is_hardcoded_valid(siret))
     end
 
     def luhn_valid(str)

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -22,4 +22,64 @@ RSpec.describe Facility, type: :model do
 
     it { is_expected.to eq 'Mc Donalds (59600 Maubeuge)' }
   end
+
+  describe 'siret validation' do
+    describe 'siret_from_query' do
+      subject { described_class.siret_from_query(query) }
+
+      context 'existing valid siret' do
+        let(:query) { '82161143100015' }
+
+        it{ is_expected.to eq '82161143100015' }
+      end
+
+      context 'nil value' do
+        let(:query) { nil }
+
+        it{ is_expected.to be_nil }
+      end
+
+      context 'empty value' do
+        let(:query) { '' }
+
+        it{ is_expected.to be_nil }
+      end
+
+      context 'nonnumeric text' do
+        let(:query) { 'some text' }
+
+        it{ is_expected.to be_nil }
+      end
+
+      context 'luhn-invalid siret' do
+        let(:query) { '82161143100010' }
+
+        it{ is_expected.to be_nil }
+      end
+
+      context 'valid siren' do
+        let(:query) { '821611431' }
+
+        it{ is_expected.to be_nil }
+      end
+
+      context 'special case for La Poste' do
+        let(:query) { '35600000012345' }
+
+        it{ is_expected.to eq '35600000012345' }
+      end
+
+      context 'valid siret with spaces and separators' do
+        let(:query) { ' 821-611_431 0001,5  ' }
+
+        it{ is_expected.to eq '82161143100015' }
+      end
+
+      context 'valid siret in text' do
+        let(:query) { 'some text, 82161143100015' }
+
+        it{ is_expected.to be_nil }
+      end
+    end
+  end
 end


### PR DESCRIPTION
While we’re here, move this code to a more decent place (the Facility model), and add validation spec.