### PR TITLE
Remove unused `of_user` scopes

### DIFF
--- a/app/models/diagnosis.rb
+++ b/app/models/diagnosis.rb
@@ -66,7 +66,6 @@ class Diagnosis < ApplicationRecord
 
   ## Scopes
   #
-  scope :of_user, (-> (user) { joins(:visit).where(visits: { advisor: user }) })
   scope :in_progress, (-> { where(step: [1..LAST_STEP - 1]) })
   scope :completed, (-> { where(step: LAST_STEP) })
   scope :available_for_expert, (lambda do |expert|

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -26,6 +26,4 @@ class Relay < ApplicationRecord
 
   validates :territory, :user, presence: true
   validates :territory, uniqueness: { scope: :user }
-
-  scope :of_user, (-> (user) { where(user: user) })
 end

--- a/app/services/admin_mailers_service.rb
+++ b/app/services/admin_mailers_service.rb
@@ -7,8 +7,11 @@ class AdminMailersService
     def send_statistics_email
       @information_hash = {}
 
-      associations = [visit: [:advisor, facility: [:company]]]
-      @not_admin_diagnoses = Diagnosis.includes(associations).only_active.of_user(User.not_admin).order(created_at: :desc)
+      @not_admin_diagnoses = Diagnosis
+        .includes([visit: [:advisor, facility: [:company]]])
+        .only_active
+        .where(visits: { advisor: User.not_admin })
+        .order(created_at: :desc)
       @completed_diagnoses = @not_admin_diagnoses.completed.updated_last_week
 
       sign_up_statistics

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -25,36 +25,6 @@ RSpec.describe Diagnosis, type: :model do
   end
 
   describe 'scopes' do
-    describe 'of_user' do
-      subject { Diagnosis.of_user user }
-
-      let(:user) { build :user }
-
-      context 'no diagnosis' do
-        it { is_expected.to eq [] }
-      end
-
-      context 'only one diagnosis' do
-        it do
-          visit = create :visit, advisor: user
-          diagnosis = create :diagnosis, visit: visit
-
-          is_expected.to eq [diagnosis]
-        end
-      end
-
-      context 'two diagnoses' do
-        it do
-          visit1 = create :visit, advisor: user
-          visit2 = create :visit, advisor: user
-          diagnosis1 = create :diagnosis, visit: visit1
-          diagnosis2 = create :diagnosis, visit: visit2
-
-          is_expected.to match_array [diagnosis1, diagnosis2]
-        end
-      end
-    end
-
     describe 'in progress' do
       subject { Diagnosis.in_progress.count }
 

--- a/spec/models/relay_spec.rb
+++ b/spec/models/relay_spec.rb
@@ -46,33 +46,4 @@ RSpec.describe Relay, type: :model do
       }
     end
   end
-
-  describe 'scopes' do
-    describe 'of_user' do
-      subject { described_class.of_user user }
-
-      let(:user) { build :user }
-
-      context 'no relay' do
-        it { is_expected.to eq [] }
-      end
-
-      context 'only one relay' do
-        it do
-          relay = create :relay, user: user
-
-          is_expected.to eq [relay]
-        end
-      end
-
-      context 'two relays' do
-        it do
-          relay1 = create :relay, user: user
-          relay2 = create :relay, user: user
-
-          is_expected.to match_array [relay1, relay2]
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
We should use named associations instead of scopes when possible.