### PR TITLE
Fix source-sans-pro font weight

### DIFF
--- a/vendor/assets/stylesheets/template-data-gouv-main.css
+++ b/vendor/assets/stylesheets/template-data-gouv-main.css
@@ -406,8 +406,7 @@ a.button.secondary {
 
 @font-face {
   font-family: "Source Sans Pro";
-  src: asset_path("")
-          url("/fonts/Source Sans Pro/SourceSansPro-Regular.otf");
+  src: url("/fonts/Source Sans Pro/SourceSansPro-Regular.otf");
   font-weight: 400;
 }
 


### PR DESCRIPTION
Fix a missed copy-pasta in the css that led the form page to always use bold for Source Sans Pro

🤷‍♂️ 