### PR TITLE
Clarify “rejected” and “no one in charge” needs

### DIFF
--- a/app/admin/diagnosed_need.rb
+++ b/app/admin/diagnosed_need.rb
@@ -14,7 +14,7 @@ ActiveAdmin.register DiagnosedNeed do
   scope :all, default: true
   scope :unsent
   scope :with_no_one_in_charge
-  scope :abandoned
+  scope :rejected
   scope :being_taken_care_of
   scope :done
   scope :not_archived

--- a/app/services/admin_mailers_service.rb
+++ b/app/services/admin_mailers_service.rb
@@ -54,14 +54,14 @@ class AdminMailersService
       @information_hash[:completed_diagnoses][:items] = @completed_diagnoses
     end
 
-    def abandoned_needs_statistics
-      abandoned_needs = DiagnosedNeed.abandoned
-      @information_hash[:abandoned_needs_count] = abandoned_needs.count
-    end
-
     def matches_count_statistics
       matches_count = Match.of_diagnoses(@completed_diagnoses).count
       @information_hash[:matches_count] = matches_count
+    end
+
+    def abandoned_needs_statistics
+      @information_hash[:rejected_needs_count] = DiagnosedNeed.rejected.count
+      @information_hash[:needs_with_no_one_in_charge_count] = DiagnosedNeed.with_no_one_in_charge.count
     end
   end
 end

--- a/app/services/expert_reminder_service.rb
+++ b/app/services/expert_reminder_service.rb
@@ -35,7 +35,7 @@ class ExpertReminderService
     end
 
     def build_matches_with_no_one_in_charge
-      DiagnosedNeed.needing_reminder.each do |diagnosed_need|
+      DiagnosedNeed.with_no_one_in_charge.each do |diagnosed_need|
         diagnosed_need.matches.each do |match|
           if match.status_not_for_me? # don’t send reminders for already rejected matches
             next

--- a/app/views/mailers/admin_mailer/weekly_statistics.html.haml
+++ b/app/views/mailers/admin_mailer/weekly_statistics.html.haml
@@ -32,6 +32,7 @@
 
 %p
   %strong= t('.completed_diagnoses_count', count: @information_hash[:completed_diagnoses][:count])
+  = t('.matches_count', count: @information_hash[:matches_count])
 - if @information_hash[:completed_diagnoses][:count].positive?
   %ul
     - @information_hash[:completed_diagnoses][:items].each do |diagnosis|
@@ -42,10 +43,13 @@
       %li= link_to description, admin_diagnosis_url(diagnosis)
 
 %p
-  %a{ href: admin_diagnosed_needs_url(scope: :abandoned) }
-    %strong= t('.abandoned_needs_count', count: @information_hash[:abandoned_needs_count])
-
-%p
-  %strong= t('.matches_count', count: @information_hash[:matches_count])
+  %strong= t('.needs_maybe_abandoned')
+  %ul
+    - if @information_hash[:rejected_needs_count].positive?
+      - description = t('.rejected_needs_count', count: @information_hash[:rejected_needs_count])
+      %li= link_to description, admin_diagnosed_needs_url(scope: :rejected)
+    - if @information_hash[:needs_with_no_one_in_charge_count].positive?
+      - description = t('.needs_with_no_one_in_charge_count', count: @information_hash[:needs_with_no_one_in_charge_count])
+      %li= link_to description, admin_diagnosed_needs_url(scope: :with_no_one_in_charge)
 
 %p= t('.see_you_next_week')

--- a/config/locales/active_admin.fr.yml
+++ b/config/locales/active_admin.fr.yml
@@ -15,7 +15,6 @@ fr:
       normalize_values: Normaliser les données
       normalize_values_done: Données normalisées
     scopes:
-      abandoned: En souffrance
       admin: Admins
       all: Tout
       archived: Archivés
@@ -24,11 +23,12 @@ fr:
       done: Clôturé
       email_not_confirmed: Email non confirmé
       not_approved: Non validés
-      not_archived: Actifs
+      not_archived: Non archivés
+      rejected: Refusés
       relays: Relais locaux
       unsent: Non envoyé
       with_custom_communes: Zone spécifique
-      with_no_one_in_charge: En attente
+      with_no_one_in_charge: Pas de réponse
       without_antenne: Sans antenne
       without_communes: Sans zone d’intervention
     territory:

--- a/config/locales/views/mailers/admin_mailer.fr.yml
+++ b/config/locales/views/mailers/admin_mailer.fr.yml
@@ -16,10 +16,6 @@ fr:
         user_has_signed_up: "%{full_name} <%{email}> vient de s’inscrire."
         view_their_account_html: "%{click_here_link} pour consulter son compte."
       weekly_statistics:
-        abandoned_needs_count:
-          one: Un besoin en souffrance
-          other: "%{count} besoins en souffrance"
-          zero: Aucun besoin en souffrance
         completed_diagnoses_count:
           one: 'Une analyse terminée :'
           other: "%{count} analyses terminées :"
@@ -35,7 +31,16 @@ fr:
           one: Une mise en relation.
           other: "%{count} mises en relation."
           zero: Aucune mise en relation.
-        see_you_next_week: A la semaine prochaine pour de nouvelles aventures !
+        needs_maybe_abandoned: Besoins potentiellement en souffrance
+        needs_with_no_one_in_charge_count:
+          one: Un besoin sans réponse
+          other: "%{count} besoins sans réponse"
+          zero: Aucun besoin sans réponse
+        rejected_needs_count:
+          one: Un besoin refusé
+          other: "%{count} besoins refusés"
+          zero: Aucun besoin refusé
+        see_you_next_week: À la semaine prochaine pour de nouvelles aventures !
         signed_up_users_count:
           one: 'Un nouvel inscrit :'
           other: "%{count} nouveaux inscrits :"

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -38,7 +38,8 @@ describe AdminMailer do
         created_diagnoses: { count: 2, items: diagnoses },
         updated_diagnoses: { count: 2, items: diagnoses },
         completed_diagnoses: { count: 2, items: diagnoses },
-        abandoned_needs_count: 2,
+        rejected_needs_count: 2,
+        needs_with_no_one_in_charge_count: 2,
         matches_count: 3
       }
     end

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -12,7 +12,9 @@ class AdminMailerPreview < ActionMailer::Preview
     updated_diagnoses = @not_admin_diagnoses.in_progress.updated_last_week
     updated_diagnoses = updated_diagnoses.where('diagnoses.created_at < ?', 1.week.ago)
 
-    abandoned_needs = DiagnosedNeed.abandoned
+    rejected_needs = DiagnosedNeed.rejected
+    needs_with_no_one_in_charge = DiagnosedNeed.with_no_one_in_charge
+
     hash = {
       signed_up_users: {
         count: recently_signed_up_users.count,
@@ -30,7 +32,8 @@ class AdminMailerPreview < ActionMailer::Preview
         count: @completed_diagnoses.count,
         items: @completed_diagnoses
       },
-      abandoned_needs_count: abandoned_needs.count,
+      rejected_needs_count: rejected_needs.count,
+      needs_with_no_one_in_charge_count: needs_with_no_one_in_charge.count,
       matches_count: 12
     }
     AdminMailer.weekly_statistics(hash)

--- a/spec/services/admin_mailers_service_spec.rb
+++ b/spec/services/admin_mailers_service_spec.rb
@@ -23,7 +23,8 @@ describe AdminMailersService do
             created_diagnoses: { count: 0, items: [] },
             updated_diagnoses: { count: 0, items: [] },
             completed_diagnoses: { count: 0, items: [] },
-            abandoned_needs_count: 0,
+            rejected_needs_count: 0,
+            needs_with_no_one_in_charge_count: 0,
             matches_count: 0
           }
         end
@@ -49,7 +50,8 @@ describe AdminMailersService do
             created_diagnoses: { count: 1, items: created_diagnoses },
             updated_diagnoses: { count: 1, items: updated_diagnoses },
             completed_diagnoses: { count: 2, items: completed_diagnoses.reverse },
-            abandoned_needs_count: 0,
+            rejected_needs_count: 0,
+            needs_with_no_one_in_charge_count: 1,
             matches_count: 3
           }
         end

--- a/spec/services/expert_reminder_service_spec.rb
+++ b/spec/services/expert_reminder_service_spec.rb
@@ -10,12 +10,12 @@ describe ExpertReminderService do
 
     before do
       allow(Match).to receive(:needing_taking_care_update).and_return(matches_needing_taking_care_update)
-      allow(DiagnosedNeed).to receive(:needing_reminder).and_return(needs_needing_reminder)
+      allow(DiagnosedNeed).to receive(:with_no_one_in_charge).and_return(needs_with_no_one_in_charge)
     end
 
     context 'experts are different' do
       let(:matches_needing_taking_care_update) { create_list :match, 2, :with_assistance_expert }
-      let(:needs_needing_reminder) { [create(:diagnosed_need, matches: create_list(:match, 2, :with_assistance_expert))] }
+      let(:needs_with_no_one_in_charge) { [create(:diagnosed_need, matches: create_list(:match, 2, :with_assistance_expert))] }
 
       it { expect { send_experts_reminders }.to change { Delayed::Job.count }.by(4) }
     end
@@ -27,7 +27,7 @@ describe ExpertReminderService do
       let(:matches_needing_taking_care_update) do
         create_list :match, 2, :with_assistance_expert, assistance_expert: assistance_expert
       end
-      let(:needs_needing_reminder) do
+      let(:needs_with_no_one_in_charge) do
         [create(:diagnosed_need, matches: create_list(:match, 2, :with_assistance_expert, assistance_expert: assistance_expert))]
       end
 
@@ -39,7 +39,7 @@ describe ExpertReminderService do
       let(:assistance_expert) { create :assistance_expert, expert: expert }
 
       let(:matches_needing_taking_care_update) { [] }
-      let(:needs_needing_reminder) { [] }
+      let(:needs_with_no_one_in_charge) { [] }
 
       it { expect { send_experts_reminders }.not_to(change { Delayed::Job.count }) }
     end

--- a/spec/views/mailers/admin_mailer/weekly_statistics.html.haml_spec.rb
+++ b/spec/views/mailers/admin_mailer/weekly_statistics.html.haml_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe 'mailers/admin_mailer/weekly_statistics.html.haml', type: :view d
         created_diagnoses: { count: 2, items: diagnoses },
         updated_diagnoses: { count: 2, items: diagnoses },
         completed_diagnoses: { count: 2, items: diagnoses },
-        matches_count: 3
+        matches_count: 3,
+        rejected_needs_count: 2,
+        needs_with_no_one_in_charge_count: 2
       }
 
       assign(:information_hash, information_hash)
@@ -22,7 +24,7 @@ RSpec.describe 'mailers/admin_mailer/weekly_statistics.html.haml', type: :view d
 
     it 'displays a title and 4 list elements' do
       expect(rendered).to include 'Bonjour, chers administrateurs !'
-      assert_select 'li', count: 7
+      assert_select 'li', count: 9
     end
   end
 
@@ -33,7 +35,9 @@ RSpec.describe 'mailers/admin_mailer/weekly_statistics.html.haml', type: :view d
         created_diagnoses: { count: 0, items: [] },
         updated_diagnoses: { count: 0, items: [] },
         completed_diagnoses: { count: 0, items: [] },
-        matches_count: 0
+        matches_count: 0,
+        rejected_needs_count: 0,
+        needs_with_no_one_in_charge_count: 0
       }
 
       assign(:information_hash, information_hash)


### PR DESCRIPTION
Now we only have
* “Rejected”: all contacted experts have explicitly rejected.
* “With no-one in charge”: not all contacted experts have responded, and no one has accepted.

Aditionally, all status-based scopes ignore the “archived” needs.