### PR TITLE
Inclure l’activité des admins dans les stats

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -6,11 +6,12 @@ class StatsController < ApplicationController
 
   def show
     @stats = Stats::Stats.new(stats_params[:stats])
-    @stats.diagnosed_needs = Stats::DiagnosedNeedsStats.new(@stats)
-    @stats.companies = Stats::CompaniesStats.new(@stats)
-    @stats.matches = Stats::MatchesStats.new(@stats)
     @stats.advisors = Stats::AdvisorsStats.new(@stats)
+    @stats.companies = Stats::CompaniesStats.new(@stats)
+    @stats.diagnosed_needs = Stats::DiagnosedNeedsStats.new(@stats)
     @stats.experts = Stats::ExpertsStats.new(@stats)
+    @stats.matches = Stats::MatchesStats.new(@stats)
+    @stats.transmitted_needs = Stats::TransmittedNeedsStats.new(@stats)
   end
 
   def users

--- a/app/services/stats/advisors_stats.rb
+++ b/app/services/stats/advisors_stats.rb
@@ -3,9 +3,7 @@ module Stats
     include BaseStats
 
     def main_query
-      User
-        .not_admin
-        .distinct
+      User.all.distinct
     end
 
     def additive_values

--- a/app/services/stats/companies_stats.rb
+++ b/app/services/stats/companies_stats.rb
@@ -4,8 +4,8 @@ module Stats
 
     def main_query
       Company
-        .where.not(facilities: { diagnoses: { advisor: User.admin } })
         .includes(:diagnosed_needs).references(:diagnosed_needs).merge(DiagnosedNeed.where.not(id: nil))
+        .where(facilities: { diagnoses: { step: Diagnosis::LAST_STEP } })
     end
 
     def date_group_attribute

--- a/app/services/stats/diagnosed_needs_stats.rb
+++ b/app/services/stats/diagnosed_needs_stats.rb
@@ -6,7 +6,6 @@ module Stats
       DiagnosedNeed
         .joins(:advisor)
         .joins(question: :category)
-        .where.not(diagnoses: { advisor: User.admin })
     end
 
     def date_group_attribute

--- a/app/services/stats/matches_stats.rb
+++ b/app/services/stats/matches_stats.rb
@@ -5,7 +5,6 @@ module Stats
     def main_query
       Match
         .joins(:advisor)
-        .where.not(diagnosed_needs: { diagnoses: { advisor: User.admin } })
     end
 
     def date_group_attribute

--- a/app/services/stats/transmitted_needs_stats.rb
+++ b/app/services/stats/transmitted_needs_stats.rb
@@ -1,0 +1,8 @@
+module Stats
+  class TransmittedNeedsStats < DiagnosedNeedsStats
+    def main_query
+      super
+        .where(diagnoses: { step: Diagnosis::LAST_STEP })
+    end
+  end
+end

--- a/app/views/stats/show.haml
+++ b/app/views/stats/show.haml
@@ -22,7 +22,7 @@
             { class: 'ui dropdown', onchange: 'this.form.submit();' })
 
 
-- names = [:diagnosed_needs, :companies, :matches, :advisors, :experts]
+- names = [:diagnosed_needs, :transmitted_needs, :companies, :matches, :advisors, :experts]
 .ui.container
   .ui.two.column.stackable.grid
     - names.each do |name|

--- a/config/locales/views/stats.fr.yml
+++ b/config/locales/views/stats.fr.yml
@@ -7,6 +7,7 @@ fr:
       diagnosed_needs: "%{count} besoins identifiés"
       experts: "%{count} référents"
       matches: "%{count} mises en relation"
+      transmitted_needs: "%{count} besoins transmis"
     show:
       all: Tous
       title: Statistiques


### PR DESCRIPTION
Dorénavant, une grande partie de la détection sera faite par l’équipe admin.

Dans le panneau des stats, on affichait les besoins détectés; j’ai changé pour afficher les besoins effectivement transmis, ce qui supprime la quantité de fausses détections faite par l’équipe pour tests. Ce n’est pas idéal non plus. Il faudrait sans doute passer du temps à les supprimer réellement.
