### PR TITLE
Fix urls reported to matomo during turbolinks events

### DIFF
--- a/app/views/matomo/_matomo.html.haml
+++ b/app/views/matomo/_matomo.html.haml
@@ -20,7 +20,7 @@
     if (!isInitialLoad) {
       var loadTimeMs = event.data.timing.visitEnd - event.data.timing.visitStart;
       _paq.push(['setReferrerUrl', window.gMatomoPreviousPageUrl]);
-      _paq.push(['setCustomUrl', '/' + window.location.href]);
+      _paq.push(['setCustomUrl', window.location.href]);
       _paq.push(['setDocumentTitle', document.title]);
       _paq.push(['setGenerationTimeMs', loadTimeMs]);
       _paq.push(['trackPageView']);


### PR DESCRIPTION
The way we report turbolinks page loads to matomo is wrong: the `/` prefix adds the whole url as a relative path, which is just wrong and creates a `https` group of pageviews on matomo. Let‘s just report the absolute url.