### PR TITLE
Remove (actually unused) ie9_fixes.sass

### DIFF
--- a/app/views/layouts/_head.html.haml
+++ b/app/views/layouts/_head.html.haml
@@ -3,8 +3,6 @@
   %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1.0' }
   = csrf_meta_tags
   = stylesheet_link_tag 'application', media: 'all', data: { turbolinks_track: 'reload' }
-  - if browser.ie?('<10')
-    = stylesheet_link_tag 'ie9_fixes', media: 'all', data: { turbolinks_track: 'reload' }
   = javascript_include_tag 'application', data: { turbolinks_track: true }
   = javascript_include_tag 'https://browser.sentry-cdn.com/4.6.4/bundle.min.js', crossorigin: 'anonymous'
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,5 +11,5 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 Rails.application.config.assets.precompile += %w[
-  solicitations.sass solicitations.js highcharts.js ie9_fixes.sass semantic-ui-calendar.min.css semantic-ui-calendar.min.js mailers.sass
+  solicitations.sass solicitations.js highcharts.js semantic-ui-calendar.min.css semantic-ui-calendar.min.js mailers.sass
 ]

--- a/vendor/assets/stylesheets/ie9_fixes.sass
+++ b/vendor/assets/stylesheets/ie9_fixes.sass
@@ -1,8 +1,0 @@
-.ui.top.menu
-  &> .ui.container
-    &> .item
-      display: inline-block
-    &> .right.menu
-      display: inline-block
-      &> .item
-        display: inline-block


### PR DESCRIPTION
Not only is this of dubious use, ui.top.menu is not (anymore?) used in the app.